### PR TITLE
Fix some non-determinism

### DIFF
--- a/examples/human.py
+++ b/examples/human.py
@@ -129,21 +129,21 @@ def userConsole(args):
 
 def build_simplification_str(args):
     """ Build simplification_str from args. """
-    simplifications = set()
+    simplifications = list()
     if args["teleport"]:
-        simplifications.add("teleportAction")
+        simplifications.append("teleportAction")
 
     if args["self_watering_plants"]:
-        simplifications.add("selfWateringFlowerPots")
+        simplifications.append("selfWateringFlowerPots")
 
     if args["open_containers"]:
-        simplifications.add("openContainers")
+        simplifications.append("openContainers")
 
     if args["open_doors"]:
-        simplifications.add("openDoors")
+        simplifications.append("openDoors")
 
     if args["no_electrical"]:
-        simplifications.add("noElectricalAction")
+        simplifications.append("noElectricalAction")
 
     return args["simplifications_preset"] or ",".join(simplifications)
 

--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -140,21 +140,21 @@ def randomModel(args):
 
 def build_simplification_str(args):
     """ Build simplification_str from args. """
-    simplifications = set()
+    simplifications = list()
     if args["teleport"]:
-        simplifications.add("teleportAction")
+        simplifications.append("teleportAction")
 
     if args["self_watering_plants"]:
-        simplifications.add("selfWateringFlowerPots")
+        simplifications.append("selfWateringFlowerPots")
 
     if args["open_containers"]:
-        simplifications.add("openContainers")
+        simplifications.append("openContainers")
 
     if args["open_doors"]:
-        simplifications.add("openDoors")
+        simplifications.append("openDoors")
 
     if args["no_electrical"]:
-        simplifications.add("noElectricalAction")
+        simplifications.append("noElectricalAction")
 
     return args["simplifications_preset"] or ",".join(simplifications)
 

--- a/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
@@ -284,7 +284,7 @@ class PythonInterface() {
 
   def getValidActionObjectCombinations():java.util.List[String] = {
     if (!agentInterface.isDefined) return List(ERROR_MESSAGE_UNINITIALIZED).asJava
-    agentInterface.get.getValidActionObjectCombinations().toList.asJava
+    agentInterface.get.getValidActionObjectCombinations().toList.sorted.asJava
   }
 
   def getValidActionObjectCombinationsJSON():String = {


### PR DESCRIPTION
While using ScienceWorld, I discovered multiple places where the program output was non-deterministic, even though the seed was set. This made my testing more difficult because each run could give a different output, even when given the same input, producing very large diffs. All problems I found were caused by the fact that Scala's and Python's set implementations have non-deterministic iteration orders. I did not do an exhaustive search, but I fixed all the cases I found during my testing. My solution was either to use a list if set access isn't needed or to sort the set contents before iteration. If this kind of contribution is welcome, I might make future PRs if other instances cause me problems.

While I was at it, I made various fixes and improvements to building the JAR file, such as fixing a bug in the `package.sh` and resolving some `sbt` warnings. I updated the JAR itself in a separate commit in case you want to drop the commit and replace it with your own. I personally wouldn't trust a JAR file from a random person on the internet, so I completely understand if you don't, either.

All code I used for testing is in [test_files.zip](https://github.com/allenai/ScienceWorld/files/9144551/test_files.zip). It includes a test script (`test_nondeterminism.py`), console output before and after my fixes (`output_before.txt` and `output_after.txt`) and JSON output of actions to make non-determinism easier to spot (`actions_sorted.json` and `actions_unsorted.json`).