### PR TITLE
Various build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .idea/**
+
+# Project-specific
+scienceworld.egg-info/
+simulator/project/build.properties
+simulator/project/project/
+simulator/project/target/
+simulator/target/

--- a/simulator/build.sbt
+++ b/simulator/build.sbt
@@ -13,4 +13,4 @@ libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % 
 libraryDependencies += "net.sf.py4j" % "py4j" % "0.10.3"
 
 // Set main class to be the Python Interface
-mainClass in Compile := Some("scienceworld.runtime.pythonapi.PythonInterface")
+Compile / mainClass := Some("scienceworld.runtime.pythonapi.PythonInterface")

--- a/simulator/build.sbt
+++ b/simulator/build.sbt
@@ -1,6 +1,6 @@
 name := "scienceworld-scala"
 
-version := "1.0.0"
+version := "1.0.2"
 
 scalaVersion := "2.12.9"
 

--- a/simulator/package.sh
+++ b/simulator/package.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 sbt assembly
-cp target/scala-2.12/scienceworld-scala-assembly-1.0.0.jar ../scienceworld/scienceworld-1.0.0.jar
+cp target/scala-2.12/scienceworld-scala-assembly-1.0.2.jar ../scienceworld/scienceworld-1.0.2.jar

--- a/simulator/package.sh
+++ b/simulator/package.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
 sbt assembly
 cp target/scala-2.12/scienceworld-scala-assembly-1.0.2.jar ../scienceworld/scienceworld-1.0.2.jar

--- a/simulator/project/plugins.sbt
+++ b/simulator/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/simulator/src/main/scala/scienceworld/runtime/AgentInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/AgentInterface.scala
@@ -320,7 +320,7 @@ class AgentInterface(val universe:EnvObject, val agent:Agent, val task:Task, var
       // Create all possible permutations of combinations of N objects
       val combos = objects combinations(numPlaceholders)
       for (combo <- combos) {
-        for (perm <- combo permutations) {
+        for (perm <- combo.permutations) {
           val outStr = new StringBuilder
           val outObjs = new ArrayBuffer[EnvObject]
 


### PR DESCRIPTION
Because the non-determinism changes in #15 proved to be controversial, I have split out the build improvements into this new PR.

In addition, I have updated `sbt-assembly` the minimal amount needed to get reproducible JAR file builds. This allows us to produce the same exact JAR file using the same source code and environment. Previously, each compilation would produce a different file, making it difficult to tell if any code changes make it into the build.

I'll leave actually building the updated JAR file up to you because I personally wouldn't trust a JAR file from a random person on the internet.