### PR TITLE
Fix order of escaping in `RunHistory.sanitizeJSON`

### DIFF
--- a/simulator/src/main/scala/scienceworld/goldagent/ExampleGoldAgent.scala
+++ b/simulator/src/main/scala/scienceworld/goldagent/ExampleGoldAgent.scala
@@ -395,8 +395,8 @@ class RunHistory(val taskName:String, val taskIdx:Int, val variationIdx:Int, val
 object RunHistory {
 
   def sanitizeJSON(in:String):String = {
-    var out = in.replace("\"", "\\\"")
-    out = out.replace("\\", "\\\\")
+    var out = in.replace("\\", "\\\\")
+    out = out.replace("\"", "\\\"")
     out = out.replace("\n", "\\n")
     out = out.replace("\r", "\\r")
     out = out.replace("\t", "\\t")


### PR DESCRIPTION
I noticed while reading through the code that the logic in [`RunHistory.sanitizeJSON`](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/simulator/src/main/scala/scienceworld/goldagent/ExampleGoldAgent.scala#L397) is incorrect. The first two string substitutions in the function need to be done in the opposite order. Backslashes need to be escaped first because escaping quotation marks adds a new backslash that will be incorrectly escaped. If you look at the string output using the Scala REPL and attempt to parse the strings with Python's `json` module, you can see the original generated JSON cannot be decoded:

```scala
scala> "In Scala, quotation marks are escaped as \\\".".replace("\"", "\\\"").replace("\\", "\\\\")
res0: String = In Scala, quotation marks are escaped as \\\\".

scala> "In Scala, quotation marks are escaped as \\\".".replace("\\", "\\\\").replace("\"", "\\\"")
res1: String = In Scala, quotation marks are escaped as \\\".
```

```python
>>> import json
>>> print(json.loads(r'"In Scala, quotation marks are escaped as \\\\"."'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ahedges/.pyenv/versions/3.8.13/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/Users/ahedges/.pyenv/versions/3.8.13/lib/python3.8/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 48 (char 47)
>>> print(json.loads(r'"In Scala, quotation marks are escaped as \\\"."'))
In Scala, quotation marks are escaped as \".
```