### PR TITLE
Prevent use-after-free in ScienceWorldEnv.shutdown

### DIFF
--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -125,6 +125,7 @@ class ScienceWorldEnv:
     def shutdown(self):
         if hasattr(self, 'gateway'):
             self.gateway.shutdown()
+            del self.gateway
 
 
     # Simplifications


### PR DESCRIPTION
I discovered a bug in the Python wrapper when using code based on the examples. The line [`random_agent.py:L136`](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/examples/random_agent.py#L136) shows the use of `shutdown()`, but including the call causes an exception to be thrown. I have created a minimal example script and reproduced the resulting error:

```python
import logging
from scienceworld import ScienceWorldEnv
logging.basicConfig(level=logging.INFO)
env = ScienceWorldEnv("")
env.shutdown()
```

```console
$ python gateway_bug.py 
Launching ScienceWorld Server (Port 25335) -- this may take a moment.
Load:  (variation: 0) (simplifications: )
INFO:py4j.java_gateway:Exception while shutting down callback server
Traceback (most recent call last):
  File "/Users/ahedges/.pyenv/versions/sciworld/lib/python3.8/site-packages/py4j/java_gateway.py", line 1983, in shutdown
    self._gateway_client.shutdown_gateway()
  File "/Users/ahedges/.pyenv/versions/sciworld/lib/python3.8/site-packages/py4j/java_gateway.py", line 1006, in shutdown_gateway
    connection = self._get_connection()
  File "/Users/ahedges/.pyenv/versions/sciworld/lib/python3.8/site-packages/py4j/java_gateway.py", line 980, in _get_connection
    raise Py4JNetworkError("Gateway is not connected.")
py4j.protocol.Py4JNetworkError: Gateway is not connected.
```

In commit 650a0f741679ab007e3e6619ebd23e01dd3c8a2c, a check was added to only call `self.gateway.shutdown()` if `self.gateway` existed. `self.gateway.shutdown()` throws an exception if called while shut down, so this seems like a reasonable precaution. However, `self.gateway` almost always exists in `ScienceWorldEnv`. It is declared in [`ScienceWorldEnv.__init__`](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/scienceworld/scienceworld.py#L25), and no code deletes it. The manual call to [`ScienceWorldEnv.shutdown`](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/scienceworld/scienceworld.py#L125) properly shuts down the gateway, but when the script ends and CPython's GC calls [`ScienceWorldEnv.__del__`](https://github.com/allenai/ScienceWorld/blob/22a70ce40e23ac9ca28e03f5b6f176a2922a8f50/scienceworld/scienceworld.py#L57) (see [`object.__del__`](https://docs.python.org/3.10/reference/datamodel.html#object.__del__) for more information), `self.gateway.shutdown()` is called a second time.

The solution to the problem is simple: delete `self.gateway` after it has been shut down so the existing `hasattr` works as was presumably intended.