### PR TITLE
Use py4j launch_gateway to launch Java server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/**
+__pycache__/
+build/
 
 # Project-specific
 scienceworld.egg-info/

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ Point your web browser to:
 # ScienceWorld Design
 ScienceWorld is written in Scala (2.12.9), and compiles using `sbt` into a JAR file that is run with `java`.  For convenience, a `python` API is provided, which interfaces using the `py4j` package.
 
-**Ports:** ScienceWorld is nominally run as a server, which interfaces to the Python API with `py4j` through a port.  The default port is `25335`.  The actual port used will be 25335 + the thread number provided when a ScienceWorld class is instantiated.
-
-**Threads:** ScienceWorld is designed to run many threads simultaneously, if desired.  To do so, initialize one `ScienceWorldEnv` object per thread, and provide a unique `threadNum` for each thread.  Don't forget to close down servers that you instantiate using the `env.shutdown()` command.  If you are spawning many threads (10+) at the same time, you may wish to add a short delay (5-10 seconds) after initialization to wait for all the servers to initialize.
-
 # Tasks
 The subtasks and their associated subtask indices are listed below.  Subtask indices are automatically assigned by sorting task names:
 

--- a/examples/human.py
+++ b/examples/human.py
@@ -12,7 +12,7 @@ def userConsole(args):
     simplificationStr = args['simplification_str']
 
     # Initialize environment
-    env = ScienceWorldEnv("", args['jar_path'], envStepLimit = args['env_step_limit'] , threadNum = 0)
+    env = ScienceWorldEnv("", args['jar_path'], envStepLimit = args['env_step_limit'])
     taskNames = env.getTaskNames()
     print("Task Names: " + str(taskNames))
 
@@ -119,10 +119,6 @@ def userConsole(args):
 
     # Display subgoal progress
     print(env.getGoalProgressStr())
-
-
-    print("Shutting down server...")
-    env.shutdown()
 
     print("Completed.")
 

--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -9,6 +9,7 @@ def randomModel(args):
     """ Example random agent -- randomly picks an action at each step. """
     exitCommands = ["quit", "exit"]
 
+
     taskIdx = args['task_num']
     simplificationStr = args['simplification_str']
     numEpisodes = args['num_episodes']
@@ -17,7 +18,8 @@ def randomModel(args):
     finalScores = []
 
     # Initialize environment
-    env = ScienceWorldEnv("", args['jar_path'], envStepLimit = args['env_step_limit'] , threadNum = 0)
+    env = ScienceWorldEnv("", args['jar_path'], envStepLimit = args['env_step_limit'])
+
     taskNames = env.getTaskNames()
     print("Task Names: " + str(taskNames))
 
@@ -132,9 +134,6 @@ def randomModel(args):
     print("---------------------------------------------------------------------")
     print("")
 
-    print("Shutting down server...")
-    env.shutdown()
-
     print("Completed.")
 
 
@@ -203,7 +202,6 @@ def parse_args():
 
 def main():
     print("ScienceWorld 1.0 API Examples - Random Agent")
-
     # Parse command line arguments
     args = parse_args()
     random.seed(args["seed"])

--- a/examples/scienceworld-web-server-example.py
+++ b/examples/scienceworld-web-server-example.py
@@ -91,7 +91,7 @@ def app():
     pywebio.session.set_env(title='ScienceWorld Demo', auto_scroll_bottom=True)
 
     # Initialize environment
-    env = ScienceWorldEnv("", serverPath=None, envStepLimit = 100, threadNum = 5)
+    env = ScienceWorldEnv("", serverPath=None, envStepLimit = 100)
 
     pywebio_out.put_markdown('## Science World (Text Simulation)')
     #put_button("Click here to export transcript", onclick=lambda: , color='success', outline=True)
@@ -195,9 +195,6 @@ def app():
 
         time.sleep(1)
 
-
-    print("Shutting down server...")
-    env.shutdown()
 
     print("Completed.")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,5 @@
+build
 pre-commit
 py4j
+pytest
+twine

--- a/scienceworld/version.py
+++ b/scienceworld/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.3rc1'
+__version__ = '1.0.3rc2'

--- a/simulator/build.sbt
+++ b/simulator/build.sbt
@@ -1,6 +1,6 @@
 name := "scienceworld-scala"
 
-version := "1.0.3rc1"
+version := "1.0.3rc2"
 
 scalaVersion := "2.12.9"
 

--- a/simulator/package.sh
+++ b/simulator/package.sh
@@ -3,4 +3,5 @@
 set -euo pipefail
 
 sbt assembly
-cp target/scala-2.12/scienceworld-scala-assembly-1.0.3rc1.jar ../scienceworld/scienceworld-1.0.3rc1.jar
+version=`cat build.sbt | grep version | cut -d '"' -f2`
+cp target/scala-2.12/scienceworld-scala-assembly-${version}.jar ../scienceworld/scienceworld-${version}.jar

--- a/simulator/src/main/scala/util/StringHelpers.scala
+++ b/simulator/src/main/scala/util/StringHelpers.scala
@@ -11,7 +11,7 @@ object StringHelpers {
   def objectListToStringDescription(objs:Set[EnvObject], perspectiveContainer:EnvObject, mode:Int = MODE_CURSORY_DETAIL, multiline:Boolean = false):String = {
     // Collect object descriptions
     val filteredObjDescs = new ArrayBuffer[String]
-    for (obj <- objs) {
+    for (obj <- objs.toList.sortBy(_.name)) {
       obj match {
         case x:Portal => {
           val desc = x.getDescriptionSafe(mode, perspectiveContainer)
@@ -44,7 +44,7 @@ object StringHelpers {
 
 
   def portalListToStringDescription(objs:Set[Portal], perspectiveContainer:EnvObject, mode:Int = MODE_CURSORY_DETAIL, multiline:Boolean = false):String = {
-    val filteredObjs = objs.map(_.getDescriptionSafe(mode, perspectiveContainer)).filter(_.isDefined).map(_.get)
+    val filteredObjs = objs.map(_.getDescriptionSafe(mode, perspectiveContainer)).filter(_.isDefined).map(_.get).toList.sorted
 
     // No contents
     if (filteredObjs.size == 0) {

--- a/tests/test_scienceworld_env.py
+++ b/tests/test_scienceworld_env.py
@@ -1,0 +1,44 @@
+from scienceworld import ScienceWorldEnv
+
+
+def test_observation_is_deterministic():
+    env = ScienceWorldEnv("task-1-boil")
+    obs_orig, _ = env.reset()
+
+    for _ in range(30):
+        obs, _ = env.reset()
+        assert obs == obs_orig
+
+        obs, _, _, _ = env.step("look around")
+        assert obs == obs_orig
+
+
+def test_multiple_instances():
+    env1 = ScienceWorldEnv("task-1-boil")
+    env2 = ScienceWorldEnv("task-1-boil")
+
+    assert env1._gateway._gateway_client.port != env2._gateway._gateway_client.port
+
+    obs1, _ = env1.reset()
+    obs2, _ = env2.reset()
+
+    # Check if the two observations are the same when ignoring the order in which objects are described.
+    assert obs1 == obs2
+
+    # Interact with one of the envs.
+    env1.step("open door to art studio")
+
+    # Check if the observations now differ from each other.
+    obs1_1, _, _, _ = env1.step("look around")
+    obs2_1, _, _, _ = env2.step("look around")
+    assert obs1_1 != obs2_1
+
+    # Resetting the second env doesn't affect the first one.
+    env2.reset()
+
+    obs1_2, _, _, _ = env1.step("look around")
+    assert obs1_1 == obs1_2
+
+    env2.step("open door to art studio")
+    obs2_2, _, _, _ = env2.step("look around")
+    assert obs1_2 == obs2_2


### PR DESCRIPTION
Right now, when creating a `ScienceWorldEnv` object, a Java server needs to be started via a call to `subprocess.Popen` .

This PR proposes to use py4j's helper function to launch and manage the java server on its own. The benefits are two folds:
1. There's no need to manually assign a port. The proposed code will automatically find one available and use it.
2. When the main Python process terminates, crashes, or gets interrupted, the associated java process is automatically killed hence avoiding creating zombie processes.

This PR contains **breaking changes**. Instantiating a `ScienceWorldEnv` object no longer needs `threadNum`, nor `launchServer`.  
Also, this PR makes issue #21 irrelevant.

I based my code on https://www.py4j.org/advanced_topics.html#using-py4j-without-pre-determined-ports-dynamic-port-number