### PR TITLE
Fix freelook being replaced with a Java exception

### DIFF
--- a/simulator/src/main/scala/scienceworld/tasks/goals/specificgoals/GoalFind.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/goals/specificgoals/GoalFind.scala
@@ -75,7 +75,9 @@ class GoalFindLivingThingStage(livingThingType:String = "", lifeStage:String = "
     if (obj.isEmpty) return GoalReturn.mkSubgoalUnsuccessful()
 
     println("GoalFindLivingThingStage()")
-    println(" -> " + obj.get.propLife.get.lifeformType)
+    if (obj.get.propLife.isDefined) {
+      println(" -> " + obj.get.propLife.get.lifeformType)
+    }
     println(" --> " + livingThingType)
     // Case: The focus is on a living thing of the correct species type
     if ((obj.get.propLife.isDefined) && (obj.get.propLife.get.lifeformType == livingThingType.toLowerCase)) {


### PR DESCRIPTION
Fixes #25.

When running `task-7-identify-life-stages-1`, focusing on an inanimate object would cause `freelook`, `inventory`, and `observation` to be replaced with `"java.util.NoSuchElementException: None.get"` instead of the proper value. This was caused by not checking whether an `Option` variable was set before trying to retrieve one of its variables. It only happened as part of console output, so it was safe to make the `println` statement conditional on whether the variable was set.

I used the following script for testing:

```python
from scienceworld import ScienceWorldEnv

env = ScienceWorldEnv("")
env.load("task-7-identify-life-stages-1", 7, "")
env.step("open door to kitchen")
env.step("go to kitchen")
*_, info = env.step("focus on thermometer")
print(repr(info["look"]))
```

Before this commit, I get the following output:

> `'java.util.NoSuchElementException: None.get'`

After this commit, I get the following output:

> `'This room is called the kitchen. In it, you see: \n\tthe agent\n\ta substance called air\n\ta chair. On the chair is: nothing.\n\ta counter. On the counter is: a bowl (containing a red apple, a banana, an orange, a potato), a drawer.\n\ta cupboard. The cupboard door is closed. \n\ta freezer. The freezer door is closed. \n\ta fridge. The fridge door is closed. \n\ta glass jar (containing a substance called sodium chloride)\n\ta lighter\n\ta oven, which is turned off. The oven door is closed. \n\ta painting\n\ta sink, which is turned off. In the sink is: nothing.\n\ta substance called soap\n\ta stopwatch, which is deactivated. \n\ta stove, which is turned off. On the stove is: nothing.\n\ta table. On the table is: a glass cup (containing nothing).\n\ta thermometer, currently reading a temperature of 10 degrees celsius\nYou also see:\n\tA door to the bathroom (that is closed)\n\tA door to the hallway (that is open)\n\tA door to the outside (that is closed)\n'`