### PR TITLE
Raise exception if task fails to load

### DIFF
--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -79,7 +79,9 @@ class ScienceWorldEnv:
             msg = "Invalid simplification. Task '{}' requires electrical actions but '--no-electrical' was provided."
             raise ValueError(msg.format(taskName))
 
-        self.server.load(self.scriptFilename, variationIdx, simplificationStr, generateGoldPath)
+        errMsg = self.server.load(self.scriptFilename, variationIdx, simplificationStr, generateGoldPath)
+        if errMsg and taskName:  # Do not raise error if intentionally loading empty task
+            raise RuntimeError(errMsg)
 
         # Reset last step score (used to calculate reward from current-previous score)
         self.lastStepScore = 0

--- a/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
+++ b/simulator/src/main/scala/scienceworld/runtime/pythonapi/PythonInterface.scala
@@ -49,7 +49,7 @@ class PythonInterface() {
   /*
    * Load/reset/shutdown server
    */
-  def load(taskStr:String, variationIdx:Int, simplificationStr:String, generateGoldPath:Boolean = false): Unit = {
+  def load(taskStr:String, variationIdx:Int, simplificationStr:String, generateGoldPath:Boolean = false): String = {
     var goldActionSequence = Array.empty[String]
 
     if (generateGoldPath) {
@@ -83,6 +83,8 @@ class PythonInterface() {
     if (generateGoldPath == true) {
       this.goldActionsStr = goldActionSequence
     }
+
+    return this.errorStr
 
   }
 


### PR DESCRIPTION
Before this commit, passing in an invalid task name to `load()`, e.g., due to a typo, would fail silently but can display a cryptic error message when making another method call. It is better to fail early with a clear error message to make the user's life easier.