### PR TITLE
Include threshold unit in temperature tasks

### DIFF
--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer.scala
@@ -203,8 +203,8 @@ class TaskUseInstrumentThermometer(val mode:String = MODE_USE_THERMOMETER) exten
       // Description
       description = "Your task is to measure the temperature of " + objectName.get + ", which is located around the " + objectLocation.get + ". "
       description += "First, focus on the thermometer. Next, focus on the " + objectName.get + ". "
-      description += "If the " + objectName.get + " temperature is above " + tempPoint.get + " degrees, place it in the " + boxAbove.get + ". "
-      description += "If the " + objectName.get + " temperature is below " + tempPoint.get + " degrees, place it in the " + boxBelow.get + ". "
+      description += "If the " + objectName.get + " temperature is above " + tempPoint.get + " degrees celsius, place it in the " + boxAbove.get + ". "
+      description += "If the " + objectName.get + " temperature is below " + tempPoint.get + " degrees celsius, place it in the " + boxBelow.get + ". "
       description += "The boxes are located around the " + boxLocation.get + ". "
 
     } else {

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer2.scala
@@ -282,8 +282,8 @@ class TaskUseInstrumentThermometer2(val mode:String = MODE_MEASURE_MELTING_KNOWN
       // Description
       description = "Your task is to measure the melting point of " + objectName.get + ", which is located around the " + objectLocation.get + ". "
       description += "First, focus on the thermometer. Next, focus on the " + objectName.get + ". "
-      description += "If the melting point of " + objectName.get + " is above " + tempPoint.get + " degrees, focus on the " + boxAbove.get + ". "
-      description += "If the melting point of " + objectName.get + " is below " + tempPoint.get + " degrees, focus on the " + boxBelow.get + ". "
+      description += "If the melting point of " + objectName.get + " is above " + tempPoint.get + " degrees celsius, focus on the " + boxAbove.get + ". "
+      description += "If the melting point of " + objectName.get + " is below " + tempPoint.get + " degrees celsius, focus on the " + boxBelow.get + ". "
       description += "The boxes are located around the " + boxLocation.get + ". "
 
     } else {

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer3.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer3.scala
@@ -231,8 +231,8 @@ class TaskUseInstrumentThermometer3(val mode:String = MODE_MEASURE_MELTING_UNKNO
       // Description
       description = "Your task is to measure the melting point of " + objectName.get + ", which is located around the " + objectLocation.get + ". "
       description += "First, focus on the thermometer. Next, focus on the " + objectName.get + ". "
-      description += "If the melting point of " + objectName.get + " is above " + tempPoint.get + " degrees, focus on the " + boxAbove.get + ". "
-      description += "If the melting point of " + objectName.get + " is below " + tempPoint.get + " degrees, focus on the " + boxBelow.get + ". "
+      description += "If the melting point of " + objectName.get + " is above " + tempPoint.get + " degrees celsius, focus on the " + boxAbove.get + ". "
+      description += "If the melting point of " + objectName.get + " is below " + tempPoint.get + " degrees celsius, focus on the " + boxBelow.get + ". "
       description += "The boxes are located around the " + boxLocation.get + ". "
 
     } else {


### PR DESCRIPTION
Closes #20.

They previously said "degrees", but that is ambiguous. It should say "degrees celsius" instead.

I happened to be looking at this code and saw the issue, so I decided to put together the 5-minute fix.