### PR TITLE
Fix `StackOverflowError` when a wire is connected to itself

### DIFF
--- a/simulator/src/main/scala/scienceworld/objects/electricalcomponent/ElectricalComponent.scala
+++ b/simulator/src/main/scala/scienceworld/objects/electricalcomponent/ElectricalComponent.scala
@@ -219,7 +219,7 @@ class Terminal(val parentObject:EnvObject, _name:String = "terminal") extends En
                 return false
               }         // Other terminal doesn't exist or is not connected in a switch, return false
               // Other terminal exists, traverse/recurse
-              if ( otherTerminal.get.connectsToGround(maxSteps-1) == true) {
+              if ( maxSteps > 0 && otherTerminal.get.connectsToGround(maxSteps-1) == true) {
                 //println("true2")
                 return true
               }      // If the recursive case returns true, then that pin connects to ground.  If it doesn't, continue on other connections.
@@ -237,7 +237,7 @@ class Terminal(val parentObject:EnvObject, _name:String = "terminal") extends En
                 return false
               }         // Other terminal doesn't exist or is not connected in a switch, return false
               // Other terminal exists, traverse/recurse
-              if ( otherTerminal.get.connectsToGround(maxSteps-1) == true) {
+              if ( maxSteps > 0 && otherTerminal.get.connectsToGround(maxSteps-1) == true) {
                 //println("true2")
                 return true
               }      // If the recursive case returns true, then that pin connects to ground.  If it doesn't, continue on other connections.
@@ -259,7 +259,7 @@ class Terminal(val parentObject:EnvObject, _name:String = "terminal") extends En
                 return false
               }         // Other terminal doesn't exist or is not connected in a switch, return false
               // Other terminal exists, traverse/recurse
-              if ( otherTerminal.get.connectsToGround(maxSteps-1) == true) {
+              if ( maxSteps > 0 && otherTerminal.get.connectsToGround(maxSteps-1) == true) {
                 //println("true2")
                 return true
               }      // If the recursive case returns true, then that pin connects to ground.  If it doesn't, continue on other connections.


### PR DESCRIPTION
During each tick, electrical components are checked for whether they connect to ground with the help of the method `Terminal.connectsToGround()`. The method contains a `maxSteps` parameter that is decremented on each recursive call to prevent infinite recursion. However, the value of `maxSteps` was never checked, so the method would recurse infinitely until the stack overflowed when one terminal of a wire was connected to the other terminal. Adding checks to stop recursing when `maxSteps` reaches 0 prevents the error.

---

I used the following script for testing:

```python
from scienceworld import ScienceWorldEnv

env = ScienceWorldEnv("")
env.load("task-2a-test-conductivity-of-unknown-substances", 380, "")
*_, info = env.step("connect orange wire terminal 2 to orange wire terminal 1")
print(repr(info["look"]))
```

Before this commit, I get the following output:

> `'java.lang.StackOverflowError'`

After this commit, I get the following output:

> `'This room is called the workshop. In it, you see: \n\tthe agent\n\ta substance called air\n\ta green box (containing nothing)\n\ta red box (containing nothing)\n\ta table. On the table is: a battery, a blue wire, a green light bulb, which is off, a orange wire, a red wire, a switch, which is off, a violet light bulb, which is off, a yellow light bulb, which is off.\n\ta ultra low temperature freezer. The ultra low temperature freezer door is closed. \n\tunknown substance R\nYou also see:\n\tA door to the hallway (that is closed)\n'`

---

To debug the issue, I created a new patch to replace the patch in <https://github.com/allenai/ScienceWorld/pull/30#issuecomment-1307891629> that worked before #30 was merged. This specific patch uses 6ba473019851c92df9be46b46d632c2db793fd66 as a base.

```diff
diff --git a/scienceworld/scienceworld.py b/scienceworld/scienceworld.py
index 227c6b5..6911444 100644
--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -30,7 +30,13 @@ class ScienceWorldEnv:

         # Launch Java side with dynamic port and get back the port on which the
         # server was bound to.
-        port = launch_gateway(classpath=serverPath, die_on_exit=True, cwd=BASEPATH)
+        import sys, time
+        port = launch_gateway(classpath=serverPath, die_on_exit=True, cwd=BASEPATH,
+                  javaopts=['-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y'],
+                  redirect_stdout=sys.stdout, redirect_stderr=sys.stderr)
+        print("Attach debugger")
+        time.sleep(10)  # Give time for user to attach debugger
+

         # Connect python side to Java side with Java dynamic port and start python
         # callback server with a dynamic port
```