### PR TITLE
Improve task name handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,36 +83,36 @@ The tasks are listed in the table below along with their number of variations. E
 
 | Task ID | Task Name                                | # Variations |
 |-------|----------------------------------------------------|------|
-|   1-1 |                                               boil |   30 |
-|   1-2 |                                               melt |   30 |
-|   1-3 |                                             freeze |   30 |
-|   1-4 |                      change-the-state-of-matter-of |   30 |
-|   2-1 |                                    use-thermometer |  540 |
-|   2-2 |            measure-melting-point-(known-substance) |  436 |
-|   2-3 |          measure-melting-point-(unknown-substance) |  300 |
-|   3-1 |                                    power-component |   20 |
-|   3-2 | power-component-(renewable-vs-nonrenewable-energy) |   20 |
-|   3-3 |                                  test-conductivity |  900 |
-|   3-4 |            test-conductivity-of-unknown-substances |  600 |
-|   4-1 |                                  find-living-thing |  300 |
-|   4-2 |                              find-non-living-thing |  300 |
-|   4-3 |                                         find-plant |  300 |
-|   4-4 |                                        find-animal |  300 |
-|   5-1 |                                         grow-plant |  126 |
-|   5-2 |                                         grow-fruit |  126 |
-|   6-1 |                                      chemistry-mix |   32 |
-|   6-2 |              chemistry-mix-paint-(secondary-color) |   36 |
-|   6-3 |               chemistry-mix-paint-(tertiary-color) |   36 |
-|   7-1 |                           lifespan-(longest-lived) |  125 |
-|   7-2 |                          lifespan-(shortest-lived) |  125 |
-|   7-3 |       lifespan-(longest-lived-then-shortest-lived) |  125 |
-|   8-1 |                             identify-life-stages-1 |   14 |
-|   8-2 |                             identify-life-stages-2 |   10 |
-|   9-1 |                     inclined-plane-determine-angle |  168 |
-|   9-2 |           inclined-plane-friction-(named-surfaces) | 1386 |
-|   9-3 |         inclined-plane-friction-(unnamed-surfaces) |  162 |
-|  10-1 |                   mendelian-genetics-(known-plant) |  120 |
-|  10-2 |                 mendelian-genetics-(unknown-plant) |  480 |
+|   1-1 |                                             boil |   30 |
+|   1-2 |                                             melt |   30 |
+|   1-3 |                                           freeze |   30 |
+|   1-4 |                    change-the-state-of-matter-of |   30 |
+|   2-1 |                                  use-thermometer |  540 |
+|   2-2 |            measure-melting-point-known-substance |  436 |
+|   2-3 |          measure-melting-point-unknown-substance |  300 |
+|   3-1 |                                  power-component |   20 |
+|   3-2 | power-component-renewable-vs-nonrenewable-energy |   20 |
+|   3-3 |                                test-conductivity |  900 |
+|   3-4 |          test-conductivity-of-unknown-substances |  600 |
+|   4-1 |                                find-living-thing |  300 |
+|   4-2 |                            find-non-living-thing |  300 |
+|   4-3 |                                       find-plant |  300 |
+|   4-4 |                                      find-animal |  300 |
+|   5-1 |                                       grow-plant |  126 |
+|   5-2 |                                       grow-fruit |  126 |
+|   6-1 |                                    chemistry-mix |   32 |
+|   6-2 |              chemistry-mix-paint-secondary-color |   36 |
+|   6-3 |               chemistry-mix-paint-tertiary-color |   36 |
+|   7-1 |                           lifespan-longest-lived |  125 |
+|   7-2 |                          lifespan-shortest-lived |  125 |
+|   7-3 |       lifespan-longest-lived-then-shortest-lived |  125 |
+|   8-1 |                           identify-life-stages-1 |   14 |
+|   8-2 |                           identify-life-stages-2 |   10 |
+|   9-1 |                   inclined-plane-determine-angle |  168 |
+|   9-2 |           inclined-plane-friction-named-surfaces | 1386 |
+|   9-3 |         inclined-plane-friction-unnamed-surfaces |  162 |
+|  10-1 |                   mendelian-genetics-known-plant |  120 |
+|  10-2 |                 mendelian-genetics-unknown-plant |  480 |
 
 # Baseline Agents
 **DRRN:** https://github.com/cognitiveailab/drrn-scienceworld

--- a/scienceworld/constants.py
+++ b/scienceworld/constants.py
@@ -1,6 +1,12 @@
+import json
 import os
 from collections import OrderedDict
 
+BASEPATH = os.path.dirname(os.path.abspath(__file__))
+JAR_FILE = 'scienceworld.jar'
+JAR_PATH = os.path.join(BASEPATH, JAR_FILE)
+TASK_FILE = 'tasks.json'
+TASK_PATH = os.path.join(BASEPATH, TASK_FILE)
 
 def is_in_debug_mode() -> bool:
     """Determine whether debug mode should be enabled.
@@ -21,72 +27,9 @@ def is_in_debug_mode() -> bool:
 
 DEBUG_MODE = is_in_debug_mode()
 
-ID2TASK = OrderedDict([
-    ("1-1", "boil"),
-    ("1-2", "melt"),
-    ("1-3", "freeze"),
-    ("1-4", "change-the-state-of-matter-of"),
-    ("2-1", "use-thermometer"),
-    ("2-2", "measure-melting-point-(known-substance)"),
-    ("2-3", "measure-melting-point-(unknown-substance)"),
-    ("3-1", "power-component"),
-    ("3-2", "power-component-(renewable-vs-nonrenewable-energy)"),
-    ("3-3", "test-conductivity"),
-    ("3-4", "test-conductivity-of-unknown-substances"),
-    ("4-1", "find-living-thing"),
-    ("4-2", "find-non-living-thing"),
-    ("4-3", "find-plant"),
-    ("4-4", "find-animal"),
-    ("5-1", "grow-plant"),
-    ("5-2", "grow-fruit"),
-    ("6-1", "chemistry-mix"),
-    ("6-2", "chemistry-mix-paint-(secondary-color)"),
-    ("6-3", "chemistry-mix-paint-(tertiary-color)"),
-    ("7-1", "lifespan-(longest-lived)"),
-    ("7-2", "lifespan-(shortest-lived)"),
-    ("7-3", "lifespan-(longest-lived-then-shortest-lived)"),
-    ("8-1", "identify-life-stages-1"),
-    ("8-2", "identify-life-stages-2"),
-    ("9-1", "inclined-plane-determine-angle"),
-    ("9-2", "inclined-plane-friction-(named-surfaces)"),
-    ("9-3", "inclined-plane-friction-(unnamed-surfaces)"),
-    ("10-1", "mendelian-genetics-(known-plant)"),
-    ("10-2", "mendelian-genetics-(unknown-plant)"),
-])
-REMOVE_PARENS = str.maketrans({'(': None, ')': None})
-for task_id in ID2TASK:
-    ID2TASK[task_id] = ID2TASK[task_id].translate(REMOVE_PARENS)
+with open(TASK_PATH) as file:
+    TASKS = json.load(file)
 
-NAME2ID = {
-    # Names used in the paper.
-    "Matter Changes of State (Boiling)": "1-1",
-    "Matter Changes of State (Melting)": "1-2",
-    "Matter Changes of State (Freezing)": "1-3",
-    "Matter Changes of State (Any)": "1-4",
-    "Measurement Use Thermometer": "2-1",
-    "Measurement Measuring Boiling Point (known)": "2-2",
-    "Measurement Measuring Boiling Point (unknown)": "2-3",
-    "Electricity Create a circuit": "3-1",
-    "Electricity Renewable vs Non-renewable Energy": "3-2",
-    "Electricity Test Conductivity (known)": "3-3",
-    "Electricity Test Conductivity (unknown)": "3-4",
-    "Classification Find a living thing": "4-1",
-    "Classification Find a non-living thing": "4-2",
-    "Classification Find a plant": "4-3",
-    "Classification Find an animal": "4-4",
-    "Biology Grow a plant": "5-1",
-    "Biology Grow a fruit": "5-2",
-    "Chemistry Mixing (generic)": "6-1",
-    "Chemistry Mixing paints (secondary colours)": "6-2",
-    "Chemistry Mixing paints (tertiary colours)": "6-3",
-    "Biology Identify longest-lived animal": "7-1",
-    "Biology Identify shortest-lived animal": "7-2",
-    "Biology Identify longest-then-shortest-lived animal": "7-3",
-    "Biology Identify life stages (plant)": "8-1",
-    "Biology Identify life stages (animal)": "8-2",
-    "Forces Inclined Planes (determine angle)": "9-1",
-    "Forces Friction (known surfaces)": "9-2",
-    "Forces Friction (unknown surfaces)": "9-3",
-    "Biology Mendelian Genetics (known plants)": "10-1",
-    "Biology Mendelian Genetics (unknown plants)": "10-2",
-}
+ID2TASK = {task['task_id']: task['task_name'] for task in TASKS}
+# Names used in the paper
+NAME2ID = {f"{task['topic']} {task['task']}": task['task_id'] for task in TASKS}

--- a/scienceworld/constants.py
+++ b/scienceworld/constants.py
@@ -56,7 +56,8 @@ ID2TASK = OrderedDict([
 
 NAME2ID = {
     # Names used in the paper.
-    "Matter Changes of State (Melting)": "1-1",
+    "Matter Changes of State (Boiling)": "1-1",
+    "Matter Changes of State (Melting)": "1-2",
     "Matter Changes of State (Freezing)": "1-3",
     "Matter Changes of State (Any)": "1-4",
     "Measurement Use Thermometer": "2-1",

--- a/scienceworld/constants.py
+++ b/scienceworld/constants.py
@@ -53,6 +53,9 @@ ID2TASK = OrderedDict([
     ("10-1", "mendelian-genetics-(known-plant)"),
     ("10-2", "mendelian-genetics-(unknown-plant)"),
 ])
+REMOVE_PARENS = str.maketrans({'(': None, ')': None})
+for task_id in ID2TASK:
+    ID2TASK[task_id] = ID2TASK[task_id].translate(REMOVE_PARENS)
 
 NAME2ID = {
     # Names used in the paper.

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -134,11 +134,11 @@ class ScienceWorldEnv:
     @property
     def task_names(self):
         """ Get the name for the supported tasks in ScienceWorld. """
-        return sorted(ID2TASK.values())
+        return list(ID2TASK.values())
 
     def getTaskNames(self):
         """ Get the name for the supported tasks in ScienceWorld. """
-        return sorted(self.server.getTaskNames())
+        return list(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -5,13 +5,8 @@ from collections import OrderedDict
 
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway, CallbackServerParameters
 
-from scienceworld.constants import DEBUG_MODE, ID2TASK, NAME2ID
+from scienceworld.constants import BASEPATH, DEBUG_MODE, ID2TASK, JAR_PATH, NAME2ID
 from scienceworld.utils import infer_task
-
-
-BASEPATH = os.path.dirname(os.path.abspath(__file__))
-JAR_FILE = 'scienceworld.jar'
-JAR_PATH = os.path.join(BASEPATH, JAR_FILE)
 
 logger = logging.getLogger(__name__)
 

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -139,11 +139,11 @@ class ScienceWorldEnv:
     @property
     def task_names(self):
         """ Get the name for the supported tasks in ScienceWorld. """
-        return list(ID2TASK.values())
+        return sorted(ID2TASK.values())
 
     def getTaskNames(self):
         """ Get the name for the supported tasks in ScienceWorld. """
-        return self.server.getTaskNames()
+        return sorted(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):

--- a/scienceworld/tasks.json
+++ b/scienceworld/tasks.json
@@ -1,0 +1,182 @@
+[
+    {
+        "task_id": "1-1",
+        "topic": "Matter",
+        "task": "Changes of State (Boiling)",
+        "task_name": "boil"
+    },
+    {
+        "task_id": "1-2",
+        "topic": "Matter",
+        "task": "Changes of State (Melting)",
+        "task_name": "melt"
+    },
+    {
+        "task_id": "1-3",
+        "topic": "Matter",
+        "task": "Changes of State (Freezing)",
+        "task_name": "freeze"
+    },
+    {
+        "task_id": "1-4",
+        "topic": "Matter",
+        "task": "Changes of State (Any)",
+        "task_name": "change-the-state-of-matter-of"
+    },
+    {
+        "task_id": "2-1",
+        "topic": "Measurement",
+        "task": "Use Thermometer",
+        "task_name": "use-thermometer"
+    },
+    {
+        "task_id": "2-2",
+        "topic": "Measurement",
+        "task": "Measuring Boiling Point (known)",
+        "task_name": "measure-melting-point-known-substance"
+    },
+    {
+        "task_id": "2-3",
+        "topic": "Measurement",
+        "task": "Measuring Boiling Point (unknown)",
+        "task_name": "measure-melting-point-unknown-substance"
+    },
+    {
+        "task_id": "3-1",
+        "topic": "Electricity",
+        "task": "Create a circuit",
+        "task_name": "power-component"
+    },
+    {
+        "task_id": "3-2",
+        "topic": "Electricity",
+        "task": "Renewable vs Non-renewable Energy",
+        "task_name": "power-component-renewable-vs-nonrenewable-energy"
+    },
+    {
+        "task_id": "3-3",
+        "topic": "Electricity",
+        "task": "Test Conductivity (known)",
+        "task_name": "test-conductivity"
+    },
+    {
+        "task_id": "3-4",
+        "topic": "Electricity",
+        "task": "Test Conductivity (unknown)",
+        "task_name": "test-conductivity-of-unknown-substances"
+    },
+    {
+        "task_id": "4-1",
+        "topic": "Classification",
+        "task": "Find a living thing",
+        "task_name": "find-living-thing"
+    },
+    {
+        "task_id": "4-2",
+        "topic": "Classification",
+        "task": "Find a non-living thing",
+        "task_name": "find-non-living-thing"
+    },
+    {
+        "task_id": "4-3",
+        "topic": "Classification",
+        "task": "Find a plant",
+        "task_name": "find-plant"
+    },
+    {
+        "task_id": "4-4",
+        "topic": "Classification",
+        "task": "Find an animal",
+        "task_name": "find-animal"
+    },
+    {
+        "task_id": "5-1",
+        "topic": "Biology",
+        "task": "Grow a plant",
+        "task_name": "grow-plant"
+    },
+    {
+        "task_id": "5-2",
+        "topic": "Biology",
+        "task": "Grow a fruit",
+        "task_name": "grow-fruit"
+    },
+    {
+        "task_id": "6-1",
+        "topic": "Chemistry",
+        "task": "Mixing (generic)",
+        "task_name": "chemistry-mix"
+    },
+    {
+        "task_id": "6-2",
+        "topic": "Chemistry",
+        "task": "Mixing paints (secondary colours)",
+        "task_name": "chemistry-mix-paint-secondary-color"
+    },
+    {
+        "task_id": "6-3",
+        "topic": "Chemistry",
+        "task": "Mixing paints (tertiary colours)",
+        "task_name": "chemistry-mix-paint-tertiary-color"
+    },
+    {
+        "task_id": "7-1",
+        "topic": "Biology",
+        "task": "Identify longest-lived animal",
+        "task_name": "lifespan-longest-lived"
+    },
+    {
+        "task_id": "7-2",
+        "topic": "Biology",
+        "task": "Identify shortest-lived animal",
+        "task_name": "lifespan-shortest-lived"
+    },
+    {
+        "task_id": "7-3",
+        "topic": "Biology",
+        "task": "Identify longest-then-shortest-lived animal",
+        "task_name": "lifespan-longest-lived-then-shortest-lived"
+    },
+    {
+        "task_id": "8-1",
+        "topic": "Biology",
+        "task": "Identify life stages (plant)",
+        "task_name": "identify-life-stages-1"
+    },
+    {
+        "task_id": "8-2",
+        "topic": "Biology",
+        "task": "Identify life stages (animal)",
+        "task_name": "identify-life-stages-2"
+    },
+    {
+        "task_id": "9-1",
+        "topic": "Forces",
+        "task": "Inclined Planes (determine angle)",
+        "task_name": "inclined-plane-determine-angle"
+    },
+    {
+        "task_id": "9-2",
+        "topic": "Forces",
+        "task": "Friction (known surfaces)",
+        "task_name": "inclined-plane-friction-named-surfaces"
+    },
+    {
+        "task_id": "9-3",
+        "topic": "Forces",
+        "task": "Friction (unknown surfaces)",
+        "task_name": "inclined-plane-friction-unnamed-surfaces"
+    },
+    {
+        "task_id": "10-1",
+        "topic": "Biology",
+        "task": "Mendelian Genetics (known plants)",
+        "task_name": "mendelian-genetics-known-plant"
+    },
+    {
+        "task_id": "10-2",
+        "topic": "Biology",
+        "task": "Mendelian Genetics (unknown plants)",
+        "task_name": "mendelian-genetics-unknown-plant"
+    }
+]

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -10,6 +10,9 @@ def infer_task(name_or_id):
     if name_or_id in ID2TASK:
         name_or_id = ID2TASK[name_or_id]
 
+    # Correct typo fixed in b807f742050ba5d9e0c5483624c39834368cd34f
+    name_or_id = name_or_id.replace("mendellian", "mendelian")
+
     # Remove prefix "task-##-" and any parentheses from task name.
     name_or_id = re.sub(r"task-(\d|a|b)+-|[()]", "", name_or_id)
 

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -10,7 +10,7 @@ def infer_task(name_or_id):
     if name_or_id in ID2TASK:
         name_or_id = ID2TASK[name_or_id]
 
-    # Remove prefix "task-##-" from task name.
-    name_or_id = re.sub(r"task-(\d|a|b)+-", "", name_or_id)
+    # Remove prefix "task-##-" and any parentheses from task name.
+    name_or_id = re.sub(r"task-(\d|a|b)+-|[()]", "", name_or_id)
 
     return name_or_id

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ contents = zipfile.ZipFile(JAR_PATH).open('META-INF/MANIFEST.MF').read().decode(
 VERSION = re.search(r'\bSpecification-Version: (.*)\b', contents).group(1)
 
 OBJECTS_LUT_FILE = "object_type_ids.tsv"
+TASKS_JSON_FILE = "tasks.json"
 
 if not os.path.isfile(JAR_PATH):
     print('ERROR: Unable to find required library:', JAR_PATH)
@@ -28,7 +29,7 @@ setup(name='scienceworld',
     packages=['scienceworld'],
     include_package_data=True,
     package_dir={'scienceworld': 'scienceworld'},
-    package_data={'scienceworld': [JAR_FILE, OBJECTS_LUT_FILE]},
+    package_data={'scienceworld': [JAR_FILE, OBJECTS_LUT_FILE, TASKS_JSON_FILE]},
     url="https://scienceworld.github.io",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(name='scienceworld',
     url="https://scienceworld.github.io",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
+    python_requires='>=3.7',
     install_requires=open('requirements.txt').readlines(),
     extras_require={
         'webserver': open('requirements.txt').readlines() + ['pywebio'],

--- a/simulator/src/main/scala/scienceworld/tasks/TaskMaker1.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/TaskMaker1.scala
@@ -28,7 +28,7 @@ class TaskMaker1 {
       return Some(this.tasks(taskName))
     }
 
-    val taskNameStripped = taskName.replaceFirst("task-(\\d|a|b)+-", "").replaceAll("[()]", "")
+    val taskNameStripped = taskName.replaceFirst("mendellian", "mendelian").replaceFirst("task-(\\d|a|b)+-", "").replaceAll("[()]", "")
     if (this.tasks.contains(taskNameStripped)) {
       return Some(this.tasks(taskNameStripped))
     }

--- a/simulator/src/main/scala/scienceworld/tasks/TaskMaker1.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/TaskMaker1.scala
@@ -28,7 +28,7 @@ class TaskMaker1 {
       return Some(this.tasks(taskName))
     }
 
-    val taskNameStripped = taskName.replaceFirst("task-(\\d|a|b)+-", "")
+    val taskNameStripped = taskName.replaceFirst("task-(\\d|a|b)+-", "").replaceAll("[()]", "")
     if (this.tasks.contains(taskNameStripped)) {
       return Some(this.tasks(taskNameStripped))
     }

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskChangeOfState.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskChangeOfState.scala
@@ -22,7 +22,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskChangeOfState(val mode:String = MODE_CHANGESTATE) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val substancePossibilities = new ArrayBuffer[ Array[TaskModifier] ]()
   // Example of water (found in the environment)

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskChemistryMix.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskChemistryMix.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.Breaks.{break, breakable}
 
 class TaskChemistryMix(val mode:String = MODE_LIVING) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
 
   // Variation 1: Which seeds to grow

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskChemistryMixPaint.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskChemistryMixPaint.scala
@@ -21,7 +21,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskChemistryMixPaint(val mode:String = MODE_CHEMISTRY_MIX_PAINT_SECONDARY) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
 
   // Variation 1: Which seeds to grow

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricCircuit.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricCircuit.scala
@@ -22,7 +22,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskElectricCircuit(val mode:String = MODE_POWER_COMPONENT) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("workshop")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity.scala
@@ -24,7 +24,7 @@ import scala.util.control.Breaks._
 
 
 class TaskElectricalConductivity(val mode:String = MODE_TEST_CONDUCTIVITY) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("workshop")
   val substanceLocations = Array("workshop", "kitchen", "living room")

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity2.scala
@@ -19,7 +19,7 @@ import scala.util.Random
 import scala.util.control.Breaks.{break, breakable}
 
 class TaskElectricalConductivity2(val mode:String = MODE_TEST_CONDUCTIVITY_UNKNOWN) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("workshop")
   val substanceLocations = Array("workshop", "kitchen", "living room")

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskFindLivingNonLiving.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskFindLivingNonLiving.scala
@@ -25,7 +25,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskFindLivingNonLiving(val mode:String = MODE_LIVING) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   // Variation 1: Animals
   val livingThings = new ArrayBuffer[ Array[TaskModifier] ]()

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskGrowPlant.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskGrowPlant.scala
@@ -33,7 +33,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskGrowPlant(val mode:String = MODE_LIVING) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
 
   // Variation 1: Which seeds to grow

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskIdentifyLifeStages1.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskIdentifyLifeStages1.scala
@@ -19,7 +19,7 @@ import scala.util.control.Breaks._
 
 
 class TaskIdentifyLifeStages1(val mode:String = MODE_LIFESTAGES) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("outside")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskIdentifyLifeStages2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskIdentifyLifeStages2.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 
 // TODO: CHANGE TO PLANTS INSTEAD OF ANIMALS?
 class TaskIdentifyLifeStages2(val mode:String = MODE_LIFESTAGES) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("outside")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskInclinedPlane1.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskInclinedPlane1.scala
@@ -24,7 +24,7 @@ import scala.util.Random
 
 
 class TaskInclinedPlane1(val mode:String = MODE_FRICTION_NAMED) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("workshop")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskInclinedPlane2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskInclinedPlane2.scala
@@ -21,7 +21,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskInclinedPlane2(val mode:String = MODE_FRICTION_UNNAMED) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("workshop")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskInclinedPlane3.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskInclinedPlane3.scala
@@ -21,7 +21,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskInclinedPlane3(val mode:String = MODE_ANGLE) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("workshop")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskLifeSpan.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskLifeSpan.scala
@@ -20,7 +20,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskLifeSpan(val mode:String = MODE_LIFESPAN_LONGEST) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("outside")
   val animalsLongLivedExamples = Array(new GiantTortoise, new Parrot, new Elephant, new Crocodile, new BrownBear)

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskMendelianGenetics1.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskMendelianGenetics1.scala
@@ -27,7 +27,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskMendelianGenetics1(val mode:String = MODE_MENDEL_KNOWN) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("greenhouse")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskMendelianGenetics2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskMendelianGenetics2.scala
@@ -25,7 +25,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskMendelianGenetics2(val mode:String = MODE_MENDEL_UNKNOWN) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("greenhouse")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer.scala
@@ -26,7 +26,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskUseInstrumentThermometer(val mode:String = MODE_USE_THERMOMETER) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("living room", "bedroom", "bathroom")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer2.scala
@@ -24,7 +24,7 @@ import scala.util.control.Breaks._
 
 
 class TaskUseInstrumentThermometer2(val mode:String = MODE_MEASURE_MELTING_KNOWN) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("kitchen")
 

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer3.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskUseInstrumentThermometer3.scala
@@ -22,7 +22,7 @@ import scala.util.control.Breaks.{break, breakable}
 
 
 class TaskUseInstrumentThermometer3(val mode:String = MODE_MEASURE_MELTING_UNKNOWN) extends TaskParametric {
-  val taskName = mode.replaceAll(" ", "-")
+  val taskName = mode.replaceAll(" ", "-").replaceAll("[()]", "")
 
   val locations = Array("kitchen")
 

--- a/tests/test_scienceworld.py
+++ b/tests/test_scienceworld.py
@@ -118,4 +118,4 @@ def test_load():
 def test_consistent_task_names():
     """Verify that Scala and Python code use the same task names."""
     env = ScienceWorldEnv()
-    assert env.task_names == env.getTaskNames()
+    assert sorted(env.task_names) == sorted(env.getTaskNames())

--- a/tests/test_scienceworld.py
+++ b/tests/test_scienceworld.py
@@ -88,8 +88,8 @@ def test_load():
         "9-1": "task-8-inclined-plane-determine-angle",
         "9-2": "task-8-inclined-plane-friction-(named-surfaces)",
         "9-3": "task-8-inclined-plane-friction-(unnamed-surfaces)",
-        "10-1": "task-9-mendelian-genetics-(known-plant)",
-        "10-2": "task-9-mendelian-genetics-(unknown-plant)"
+        "10-1": "task-9-mendellian-genetics-(known-plant)",
+        "10-2": "task-9-mendellian-genetics-(unknown-plant)"
     }
 
     env = ScienceWorldEnv()

--- a/tests/test_scienceworld.py
+++ b/tests/test_scienceworld.py
@@ -114,3 +114,8 @@ def test_load():
         obs2, info2 = env.reset()
         assert obs1 == obs2, f"{task_id} is not the same as {task_name}"
         assert info1 == info2, f"{task_id} is not the same as {task_name}"
+
+def test_consistent_task_names():
+    """Verify that Scala and Python code use the same task names."""
+    env = ScienceWorldEnv()
+    assert env.task_names == env.getTaskNames()


### PR DESCRIPTION
Building off the work in #44, I've made some improvements to the handling of task names while hopefully maintaining backwards compatibility.

The new file `tasks.json` was generated using the files in [json_creation.zip](https://github.com/allenai/ScienceWorld/files/10348397/json_creation.zip):

- `task_names.json`: A file created for internal use from data in the paper and repository
- `convert.py`: A script to combine our JSON file and your `dict`s into a new file for inclusion in the library

I didn't actually test my changes by running ScienceWorld, but the tests make me pretty confident it would work.