### PR TITLE
Fix `TypeError` in `logging` call

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-case-conflict
@@ -23,17 +23,17 @@ repos:
       - id: fix-byte-order-marker
       - id: fix-encoding-pragma
         args: [--remove]
-      - id: forbid-new-submodules
+      - id: forbid-submodules
       - id: mixed-line-ending
         args: ['--fix', 'lf']
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/shellcheck-py/shellcheck-py # Unofficial but maintained by asottile
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
+    rev: v2.2.2
     hooks:
       - id: codespell
         args: [

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -26,7 +26,7 @@ class ScienceWorldEnv:
                 classpath=serverPath, die_on_exit=True, cwd=BASEPATH,
                 javaopts=['-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y'],
                 redirect_stdout=sys.stdout, redirect_stderr=sys.stderr)
-            print("Attach debugger within the next 10 seconds")
+            logger.debug("Attach debugger within the next 10 seconds")
             time.sleep(10)  # Give time for user to attach debugger
         else:
             port = launch_gateway(classpath=serverPath, die_on_exit=True, cwd=BASEPATH)

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -48,7 +48,7 @@ class ScienceWorldEnv:
             python_port)
 
         self.server = self._gateway.jvm.scienceworld.runtime.pythonapi.PythonInterface()
-        logger.info("ScienceWorld server running on port", port)
+        logger.info("ScienceWorld server running on port %d", port)
 
         # Keep track of the last step score, to calculate reward from score
         self.lastStepScore = 0


### PR DESCRIPTION
Without the `%d` present in the log message string, the call to `logger.info()` as always throwing a `TypeError` upon running the server.

I also made two other small changes while I was at it.