### PR TITLE
Add PEP 8 compliant api, and add deprecation warnings to camel case api methods.

### DIFF
--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -11,7 +11,6 @@ from scienceworld.utils import infer_task, deprecated_api_warning
 logger = logging.getLogger(__name__)
 
 
-
 class ScienceWorldEnv:
 
     def __init__(self, taskName=None, serverPath=None, envStepLimit=100):
@@ -121,12 +120,12 @@ class ScienceWorldEnv:
 
     # Simplifications
     def getSimplificationsUsed(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getSimplificationsUsed()
 
     def getPossibleSimplifications(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getPossibleSimplifications().split(", ")
 
@@ -142,40 +141,39 @@ class ScienceWorldEnv:
 
     def getTaskNames(self):
         """ Get the name for the supported tasks in ScienceWorld. """
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return list(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getTaskMaxVariations(infer_task(taskName))
 
     # Get possible actions
     def getPossibleActions(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return list(self.server.getPossibleActions())
 
     # Get possible actions (and also include the template IDs for those actions)
     def getPossibleActionsWithIDs(self):
+        deprecated_api_warning(logger, True, True)
 
-        deprecated_api_warning(True, True)
         jsonStr = self.server.getPossibleActionsWithIDs()
         data = json.loads(jsonStr)
         return data
 
     # Get possible objects
     def getPossibleObjects(self):
+        deprecated_api_warning(logger, True, True)
 
-        deprecated_api_warning(True, True)
         return list(self.server.getPossibleObjects())
 
     # Get a list of object_ids to unique referents
     def getPossibleObjectReferentLUT(self):
-
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         jsonStr = self.server.getPossibleObjectReferentLUTJSON()
         data = json.loads(jsonStr)
@@ -183,7 +181,7 @@ class ScienceWorldEnv:
 
     # As above, but dictionary is referenced by object type ID
     def getPossibleObjectReferentTypesLUT(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         jsonStr = self.server.getPossibleObjectReferentTypesLUTJSON()
         data = json.loads(jsonStr)
@@ -191,12 +189,12 @@ class ScienceWorldEnv:
 
     # Get a list of *valid* agent-object combinations
     def getValidActionObjectCombinations(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return list(self.server.getValidActionObjectCombinations())
 
     def getValidActionObjectCombinationsWithTemplates(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         jsonStr = self.server.getValidActionObjectCombinationsJSON()
         data = json.loads(jsonStr)
@@ -204,7 +202,7 @@ class ScienceWorldEnv:
 
     # Get a LUT of object_id to type_id
     def getAllObjectTypesLUTJSON(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         jsonStr = self.server.getAllObjectTypesLUTJSON()
         data = json.loads(jsonStr)
@@ -212,7 +210,7 @@ class ScienceWorldEnv:
 
     # Get a LUT of {object_id: {type_id, referent:[]} } tuples
     def getAllObjectIdsTypesReferentsLUTJSON(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         jsonStr = self.server.getAllObjectIdsTypesReferentsLUTJSON()
         data = json.loads(jsonStr)
@@ -220,7 +218,7 @@ class ScienceWorldEnv:
 
     # Get possible action/object combinations
     def getPossibleActionObjectCombinations(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         combinedJSON = self.server.getPossibleActionObjectCombinationsJSON()
         data = json.loads(combinedJSON)
@@ -231,7 +229,7 @@ class ScienceWorldEnv:
 
     # Get a list of object types and their IDs
     def getObjectTypes(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         jsonStr = self.server.getObjectTypesLUTJSON()
         data = json.loads(jsonStr)
@@ -239,7 +237,7 @@ class ScienceWorldEnv:
 
     # Get the vocabulary of the model (at the current state)
     def getVocabulary(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         vocab = set()
 
@@ -256,12 +254,12 @@ class ScienceWorldEnv:
 
 
     def getNumMoves(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getNumMoves()
 
     def getTaskDescription(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getTaskDescription()
 
@@ -269,7 +267,7 @@ class ScienceWorldEnv:
     # History
     #
     def getRunHistory(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         historyStr = self.server.getRunHistoryJSON()
         jsonOut = json.loads(historyStr)
@@ -278,7 +276,7 @@ class ScienceWorldEnv:
 
     # History saving (provides an API to do this, so it's consistent across agents)
     def storeRunHistory(self, episodeIdxKey, notes):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         packed = {
             'episodeIdx': episodeIdxKey,
@@ -289,7 +287,7 @@ class ScienceWorldEnv:
         self.runHistories[episodeIdxKey] = packed
 
     def saveRunHistories(self, filenameOutPrefix):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         # Save history
 
@@ -309,18 +307,18 @@ class ScienceWorldEnv:
             json.dump(self.runHistories, outfile, sort_keys=True, indent=4)
 
     def getRunHistorySize(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return len(self.runHistories)
 
     def clearRunHistories(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         self.runHistories = {}
 
     # A one-stop function to handle saving.
     def saveRunHistoriesBufferIfFull(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         if ((self.getRunHistorySize() >= maxPerFile) or (forceSave == True)):
             self.saveRunHistories(filenameOutPrefix)
@@ -331,38 +329,38 @@ class ScienceWorldEnv:
     # Train/development/test sets
     #
     def getVariationsTrain(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return list(self.server.getVariationsTrain())
 
     def getVariationsDev(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return list(self.server.getVariationsDev())
 
     def getVariationsTest(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return list(self.server.getVariationsTest())
 
     def getRandomVariationTrain(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getRandomVariationTrain()
 
     def getRandomVariationDev(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getRandomVariationDev()
 
     def getRandomVariationTest(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         return self.server.getRandomVariationTest()
 
     # Gold action sequence
     def getGoldActionSequence(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         if (self.goldPathGenerated == True):
             return list(self.server.getGoldActionSequence())
@@ -421,7 +419,7 @@ class ScienceWorldEnv:
 
     # Goal progress
     def getGoalProgressStr(self):
-        deprecated_api_warning(True, True)
+        deprecated_api_warning(logger, True, True)
 
         goalStr = self.server.getGoalProgressStr()
         return goalStr

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -142,8 +142,8 @@ class ScienceWorldEnv:
         return list(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
-    def get_max_variations(self, taskName):
-        return self.server.getTaskMaxVariations(infer_task(taskName))
+    def get_max_variations(self, task_name):
+        return self.server.getTaskMaxVariations(infer_task(task_name))
 
     # Get possible actions
     def get_possible_actions(self):
@@ -239,20 +239,20 @@ class ScienceWorldEnv:
 
 
     # History saving (provides an API to do this, so it's consistent across agents)
-    def store_run_history(self, episodeIdxKey, notes):
+    def store_run_history(self, episode_idx_key, notes):
         packed = {
-            'episodeIdx': episodeIdxKey,
+            'episodeIdx': episode_idx_key,
             'notes': notes,
             'history': self.get_run_history()
         }
 
         self.runHistories[episodeIdxKey] = packed
 
-    def save_run_histories(self, filenameOutPrefix):
+    def save_run_histories(self, filename_out_prefix):
         # Save history
 
         # Create verbose filename
-        filenameOut = filenameOutPrefix
+        filenameOut = filename_out_prefix
         keys = sorted(self.runHistories.keys())
         if (len(keys) > 0):
             keyFirst = keys[0]
@@ -273,9 +273,9 @@ class ScienceWorldEnv:
         self.runHistories = {}
 
     # A one-stop function to handle saving.
-    def save_run_histories_buffer_if_full(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
-        if ((self.get_run_history_size() >= maxPerFile) or (forceSave == True)):
-            self.save_run_histories(filenameOutPrefix)
+    def save_run_histories_buffer_if_full(self, filename_out_prefix, max_per_file=1000, force_save=False):
+        if ((self.get_run_history_size() >= max_per_file) or (force_save == True)):
+            self.save_run_histories(filename_out_prefix)
             self.clear_run_histories()
 
 
@@ -309,11 +309,11 @@ class ScienceWorldEnv:
 
 
     # Step
-    def step(self, inputStr:str):
-        observation = self.server.step(inputStr)
+    def step(self, input_str:str):
+        observation = self.server.step(input_str)
         score = int(round(100 * self.server.getScore()))        # Convert from 0-1 to 0-100
         isCompleted = self.server.getCompleted()
-        numMoves = self.getNumMoves()
+        numMoves = self.get_num_moves()
 
         # Calculate reward
         reward = score - self.lastStepScore         # Calculate reward (delta score) for this step
@@ -336,7 +336,7 @@ class ScienceWorldEnv:
             'look': self.look(),
             'inv': self.inventory(),
             'taskDesc': self.taskdescription(),
-            'valid': self.getValidActionObjectCombinations(),
+            'valid': self.get_valid_action_object_combinations(),
             'variationIdx': self.variationIdx,
             'taskName': self.taskName,
             'simplificationStr': self.simplificationStr,

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway, CallbackServerParameters
 
 from scienceworld.constants import BASEPATH, DEBUG_MODE, ID2TASK, JAR_PATH, NAME2ID
-from scienceworld.utils import infer_task
+from scienceworld.utils import infer_task, deprecated_api_warning
 
 logger = logging.getLogger(__name__)
 
@@ -122,9 +122,11 @@ class ScienceWorldEnv:
 
     # Simplifications
     def getSimplificationsUsed(self):
+        deprecated_api_warning(True, True)
         return self.server.getSimplificationsUsed()
 
     def getPossibleSimplifications(self):
+        deprecated_api_warning(True, True)
         return self.server.getPossibleSimplifications().split(", ")
 
     @property
@@ -139,14 +141,17 @@ class ScienceWorldEnv:
 
     def getTaskNames(self):
         """ Get the name for the supported tasks in ScienceWorld. """
+        deprecated_api_warning(True, True)
         return list(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):
+        deprecated_api_warning(True, True)
         return self.server.getTaskMaxVariations(infer_task(taskName))
 
     # Get possible actions
     def getPossibleActions(self):
+        deprecated_api_warning(True, True)
         return list(self.server.getPossibleActions())
 
     # Get possible actions (and also include the template IDs for those actions)

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway, CallbackServerParameters
 
 from scienceworld.constants import BASEPATH, DEBUG_MODE, ID2TASK, JAR_PATH, NAME2ID
-from scienceworld.utils import infer_task, deprecated_api_warning
+from scienceworld.utils import infer_task, snake_case_deprecation_warning
 
 logger = logging.getLogger(__name__)
 
@@ -120,12 +120,12 @@ class ScienceWorldEnv:
 
     # Simplifications
     def getSimplificationsUsed(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getSimplificationsUsed()
 
     def getPossibleSimplifications(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getPossibleSimplifications().split(", ")
 
@@ -141,25 +141,25 @@ class ScienceWorldEnv:
 
     def getTaskNames(self):
         """ Get the name for the supported tasks in ScienceWorld. """
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getTaskMaxVariations(infer_task(taskName))
 
     # Get possible actions
     def getPossibleActions(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getPossibleActions())
 
     # Get possible actions (and also include the template IDs for those actions)
     def getPossibleActionsWithIDs(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getPossibleActionsWithIDs()
         data = json.loads(jsonStr)
@@ -167,13 +167,13 @@ class ScienceWorldEnv:
 
     # Get possible objects
     def getPossibleObjects(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getPossibleObjects())
 
     # Get a list of object_ids to unique referents
     def getPossibleObjectReferentLUT(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getPossibleObjectReferentLUTJSON()
         data = json.loads(jsonStr)
@@ -181,7 +181,7 @@ class ScienceWorldEnv:
 
     # As above, but dictionary is referenced by object type ID
     def getPossibleObjectReferentTypesLUT(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getPossibleObjectReferentTypesLUTJSON()
         data = json.loads(jsonStr)
@@ -189,12 +189,12 @@ class ScienceWorldEnv:
 
     # Get a list of *valid* agent-object combinations
     def getValidActionObjectCombinations(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getValidActionObjectCombinations())
 
     def getValidActionObjectCombinationsWithTemplates(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getValidActionObjectCombinationsJSON()
         data = json.loads(jsonStr)
@@ -202,7 +202,7 @@ class ScienceWorldEnv:
 
     # Get a LUT of object_id to type_id
     def getAllObjectTypesLUTJSON(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getAllObjectTypesLUTJSON()
         data = json.loads(jsonStr)
@@ -210,7 +210,7 @@ class ScienceWorldEnv:
 
     # Get a LUT of {object_id: {type_id, referent:[]} } tuples
     def getAllObjectIdsTypesReferentsLUTJSON(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getAllObjectIdsTypesReferentsLUTJSON()
         data = json.loads(jsonStr)
@@ -218,7 +218,7 @@ class ScienceWorldEnv:
 
     # Get possible action/object combinations
     def getPossibleActionObjectCombinations(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         combinedJSON = self.server.getPossibleActionObjectCombinationsJSON()
         data = json.loads(combinedJSON)
@@ -229,7 +229,7 @@ class ScienceWorldEnv:
 
     # Get a list of object types and their IDs
     def getObjectTypes(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         jsonStr = self.server.getObjectTypesLUTJSON()
         data = json.loads(jsonStr)
@@ -237,7 +237,7 @@ class ScienceWorldEnv:
 
     # Get the vocabulary of the model (at the current state)
     def getVocabulary(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         vocab = set()
 
@@ -254,12 +254,12 @@ class ScienceWorldEnv:
 
 
     def getNumMoves(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getNumMoves()
 
     def getTaskDescription(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getTaskDescription()
 
@@ -267,7 +267,7 @@ class ScienceWorldEnv:
     # History
     #
     def getRunHistory(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         historyStr = self.server.getRunHistoryJSON()
         jsonOut = json.loads(historyStr)
@@ -276,7 +276,7 @@ class ScienceWorldEnv:
 
     # History saving (provides an API to do this, so it's consistent across agents)
     def storeRunHistory(self, episodeIdxKey, notes):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         packed = {
             'episodeIdx': episodeIdxKey,
@@ -287,7 +287,7 @@ class ScienceWorldEnv:
         self.runHistories[episodeIdxKey] = packed
 
     def saveRunHistories(self, filenameOutPrefix):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         # Save history
 
@@ -307,18 +307,18 @@ class ScienceWorldEnv:
             json.dump(self.runHistories, outfile, sort_keys=True, indent=4)
 
     def getRunHistorySize(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return len(self.runHistories)
 
     def clearRunHistories(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         self.runHistories = {}
 
     # A one-stop function to handle saving.
     def saveRunHistoriesBufferIfFull(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         if ((self.getRunHistorySize() >= maxPerFile) or (forceSave == True)):
             self.saveRunHistories(filenameOutPrefix)
@@ -329,38 +329,38 @@ class ScienceWorldEnv:
     # Train/development/test sets
     #
     def getVariationsTrain(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getVariationsTrain())
 
     def getVariationsDev(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getVariationsDev())
 
     def getVariationsTest(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return list(self.server.getVariationsTest())
 
     def getRandomVariationTrain(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getRandomVariationTrain()
 
     def getRandomVariationDev(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getRandomVariationDev()
 
     def getRandomVariationTest(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         return self.server.getRandomVariationTest()
 
     # Gold action sequence
     def getGoldActionSequence(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         if (self.goldPathGenerated == True):
             return list(self.server.getGoldActionSequence())
@@ -419,7 +419,7 @@ class ScienceWorldEnv:
 
     # Goal progress
     def getGoalProgressStr(self):
-        deprecated_api_warning(logger, True, True)
+        snake_case_deprecation_warning()
 
         goalStr = self.server.getGoalProgressStr()
         return goalStr

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -364,7 +364,8 @@ class ScienceWorldEnv:
 
     ########################## SNAKE CASE METHODS #############################
     # As of 23-12-14, all of the snake case methods are exact copies of their 
-    # camelCase counterparts
+    # camelCase counterparts (except that they use snake case in the method name
+    # and that they use the snake case variants of methods)
 
 
     # Simplifications
@@ -449,12 +450,12 @@ class ScienceWorldEnv:
         vocab = set()
 
         # Action vocabulary
-        for actionStr in self.getPossibleActions():
+        for actionStr in self.get_possible_actions():
             for word in actionStr.split(" "):
                 vocab.add(word)
 
         # Object vocabulary (keep as compound nouns?)
-        vocabObjects = self.getPossibleObjects()
+        vocabObjects = self.get_possible_objects()
         vocab = vocab.union( set(vocabObjects) )
 
         return vocab
@@ -480,7 +481,7 @@ class ScienceWorldEnv:
         packed = {
             'episodeIdx': episodeIdxKey,
             'notes': notes,
-            'history': self.getRunHistory()
+            'history': self.get_run_history()
         }
 
         self.runHistories[episodeIdxKey] = packed
@@ -511,9 +512,9 @@ class ScienceWorldEnv:
 
     # A one-stop function to handle saving.
     def save_run_histories_buffer_if_full(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
-        if ((self.getRunHistorySize() >= maxPerFile) or (forceSave == True)):
-            self.saveRunHistories(filenameOutPrefix)
-            self.clearRunHistories()
+        if ((self.get_run_history_size() >= maxPerFile) or (forceSave == True)):
+            self.save_run_histories(filenameOutPrefix)
+            self.clear_run_histories()
 
 
     #
@@ -548,7 +549,6 @@ class ScienceWorldEnv:
     def get_goal_progress_str(self):
         goalStr = self.server.getGoalProgressStr()
         return goalStr
-
 
 
 class BufferedHistorySaver:

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -1,7 +1,6 @@
 import os
 import json
 import logging
-import warning
 from collections import OrderedDict
 
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway, CallbackServerParameters
@@ -123,10 +122,12 @@ class ScienceWorldEnv:
     # Simplifications
     def getSimplificationsUsed(self):
         deprecated_api_warning(True, True)
+
         return self.server.getSimplificationsUsed()
 
     def getPossibleSimplifications(self):
         deprecated_api_warning(True, True)
+
         return self.server.getPossibleSimplifications().split(", ")
 
     @property
@@ -142,63 +143,85 @@ class ScienceWorldEnv:
     def getTaskNames(self):
         """ Get the name for the supported tasks in ScienceWorld. """
         deprecated_api_warning(True, True)
+
         return list(self.server.getTaskNames())
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):
         deprecated_api_warning(True, True)
+
         return self.server.getTaskMaxVariations(infer_task(taskName))
 
     # Get possible actions
     def getPossibleActions(self):
         deprecated_api_warning(True, True)
+
         return list(self.server.getPossibleActions())
 
     # Get possible actions (and also include the template IDs for those actions)
     def getPossibleActionsWithIDs(self):
+
+        deprecated_api_warning(True, True)
         jsonStr = self.server.getPossibleActionsWithIDs()
         data = json.loads(jsonStr)
         return data
 
     # Get possible objects
     def getPossibleObjects(self):
+
+        deprecated_api_warning(True, True)
         return list(self.server.getPossibleObjects())
 
     # Get a list of object_ids to unique referents
     def getPossibleObjectReferentLUT(self):
+
+        deprecated_api_warning(True, True)
+
         jsonStr = self.server.getPossibleObjectReferentLUTJSON()
         data = json.loads(jsonStr)
         return data
 
     # As above, but dictionary is referenced by object type ID
     def getPossibleObjectReferentTypesLUT(self):
+        deprecated_api_warning(True, True)
+
         jsonStr = self.server.getPossibleObjectReferentTypesLUTJSON()
         data = json.loads(jsonStr)
         return data
 
     # Get a list of *valid* agent-object combinations
     def getValidActionObjectCombinations(self):
+        deprecated_api_warning(True, True)
+
         return list(self.server.getValidActionObjectCombinations())
 
     def getValidActionObjectCombinationsWithTemplates(self):
+        deprecated_api_warning(True, True)
+
         jsonStr = self.server.getValidActionObjectCombinationsJSON()
         data = json.loads(jsonStr)
         return data['validActions']
 
     # Get a LUT of object_id to type_id
     def getAllObjectTypesLUTJSON(self):
+        deprecated_api_warning(True, True)
+
         jsonStr = self.server.getAllObjectTypesLUTJSON()
         data = json.loads(jsonStr)
         return data
 
     # Get a LUT of {object_id: {type_id, referent:[]} } tuples
     def getAllObjectIdsTypesReferentsLUTJSON(self):
+        deprecated_api_warning(True, True)
+
         jsonStr = self.server.getAllObjectIdsTypesReferentsLUTJSON()
         data = json.loads(jsonStr)
         return data
 
     # Get possible action/object combinations
     def getPossibleActionObjectCombinations(self):
+        deprecated_api_warning(True, True)
+
         combinedJSON = self.server.getPossibleActionObjectCombinationsJSON()
         data = json.loads(combinedJSON)
         templates = data['templates']
@@ -208,12 +231,16 @@ class ScienceWorldEnv:
 
     # Get a list of object types and their IDs
     def getObjectTypes(self):
+        deprecated_api_warning(True, True)
+
         jsonStr = self.server.getObjectTypesLUTJSON()
         data = json.loads(jsonStr)
         return data
 
     # Get the vocabulary of the model (at the current state)
     def getVocabulary(self):
+        deprecated_api_warning(True, True)
+
         vocab = set()
 
         # Action vocabulary
@@ -229,15 +256,21 @@ class ScienceWorldEnv:
 
 
     def getNumMoves(self):
+        deprecated_api_warning(True, True)
+
         return self.server.getNumMoves()
 
     def getTaskDescription(self):
+        deprecated_api_warning(True, True)
+
         return self.server.getTaskDescription()
 
     #
     # History
     #
     def getRunHistory(self):
+        deprecated_api_warning(True, True)
+
         historyStr = self.server.getRunHistoryJSON()
         jsonOut = json.loads(historyStr)
         return jsonOut
@@ -245,6 +278,8 @@ class ScienceWorldEnv:
 
     # History saving (provides an API to do this, so it's consistent across agents)
     def storeRunHistory(self, episodeIdxKey, notes):
+        deprecated_api_warning(True, True)
+
         packed = {
             'episodeIdx': episodeIdxKey,
             'notes': notes,
@@ -254,6 +289,8 @@ class ScienceWorldEnv:
         self.runHistories[episodeIdxKey] = packed
 
     def saveRunHistories(self, filenameOutPrefix):
+        deprecated_api_warning(True, True)
+
         # Save history
 
         # Create verbose filename
@@ -272,13 +309,19 @@ class ScienceWorldEnv:
             json.dump(self.runHistories, outfile, sort_keys=True, indent=4)
 
     def getRunHistorySize(self):
+        deprecated_api_warning(True, True)
+
         return len(self.runHistories)
 
     def clearRunHistories(self):
+        deprecated_api_warning(True, True)
+
         self.runHistories = {}
 
     # A one-stop function to handle saving.
     def saveRunHistoriesBufferIfFull(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
+        deprecated_api_warning(True, True)
+
         if ((self.getRunHistorySize() >= maxPerFile) or (forceSave == True)):
             self.saveRunHistories(filenameOutPrefix)
             self.clearRunHistories()
@@ -288,25 +331,39 @@ class ScienceWorldEnv:
     # Train/development/test sets
     #
     def getVariationsTrain(self):
+        deprecated_api_warning(True, True)
+
         return list(self.server.getVariationsTrain())
 
     def getVariationsDev(self):
+        deprecated_api_warning(True, True)
+
         return list(self.server.getVariationsDev())
 
     def getVariationsTest(self):
+        deprecated_api_warning(True, True)
+
         return list(self.server.getVariationsTest())
 
     def getRandomVariationTrain(self):
+        deprecated_api_warning(True, True)
+
         return self.server.getRandomVariationTrain()
 
     def getRandomVariationDev(self):
+        deprecated_api_warning(True, True)
+
         return self.server.getRandomVariationDev()
 
     def getRandomVariationTest(self):
+        deprecated_api_warning(True, True)
+
         return self.server.getRandomVariationTest()
 
     # Gold action sequence
     def getGoldActionSequence(self):
+        deprecated_api_warning(True, True)
+
         if (self.goldPathGenerated == True):
             return list(self.server.getGoldActionSequence())
         else:
@@ -364,6 +421,8 @@ class ScienceWorldEnv:
 
     # Goal progress
     def getGoalProgressStr(self):
+        deprecated_api_warning(True, True)
+
         goalStr = self.server.getGoalProgressStr()
         return goalStr
 

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -119,15 +119,13 @@ class ScienceWorldEnv:
         return observation, info
 
     # Simplifications
-    def getSimplificationsUsed(self):
-        snake_case_deprecation_warning()
+    def get_simplifications_used(self):
+        return self.server.getSimplificationsUsed()
 
-        return self.get_simplifications_used()
+    def get_possible_simplifications(self):
+        return self.server.getPossibleSimplifications().split(", ")
 
-    def getPossibleSimplifications(self):
-        snake_case_deprecation_warning()
 
-        return self.get_possible_simplifications()
 
     @property
     def tasks(self):
@@ -138,243 +136,6 @@ class ScienceWorldEnv:
     def task_names(self):
         """ Get the name for the supported tasks in ScienceWorld. """
         return list(ID2TASK.values())
-
-    def getTaskNames(self):
-        """ Get the name for the supported tasks in ScienceWorld. """
-        snake_case_deprecation_warning()
-
-        return self.get_task_names()
-
-    # Get the maximum number of variations for this task
-    def getMaxVariations(self, taskName):
-        snake_case_deprecation_warning()
-
-        return self.get_max_variations(taskName)
-
-    # Get possible actions
-    def getPossibleActions(self):
-        snake_case_deprecation_warning()
-
-        return self.get_possible_actions()
-
-    # Get possible actions (and also include the template IDs for those actions)
-    def getPossibleActionsWithIDs(self):
-        snake_case_deprecation_warning()
-
-        return self.get_possible_actions_with_IDs()
-
-    # Get possible objects
-    def getPossibleObjects(self):
-        snake_case_deprecation_warning()
-
-        return self.get_possible_objects()
-
-    # Get a list of object_ids to unique referents
-    def getPossibleObjectReferentLUT(self):
-        snake_case_deprecation_warning()
-
-        return self.get_possible_object_referent_LUT()
-
-    # As above, but dictionary is referenced by object type ID
-    def getPossibleObjectReferentTypesLUT(self):
-        snake_case_deprecation_warning()
-
-        return self.get_possible_object_referent_types_LUT()
-
-    # Get a list of *valid* agent-object combinations
-    def getValidActionObjectCombinations(self):
-        snake_case_deprecation_warning()
-
-        return self.get_valid_action_object_combinations()
-
-    def getValidActionObjectCombinationsWithTemplates(self):
-        snake_case_deprecation_warning()
-
-        return self.get_valid_action_object_combinations_with_templates()
-
-    # Get a LUT of object_id to type_id
-    def getAllObjectTypesLUTJSON(self):
-        snake_case_deprecation_warning()
-
-        return self.get_all_object_types_LUTJSON()
-
-    # Get a LUT of {object_id: {type_id, referent:[]} } tuples
-    def getAllObjectIdsTypesReferentsLUTJSON(self):
-        snake_case_deprecation_warning()
-
-        return self.get_all_object_ids_types_referents_LUTJSON()
-
-    # Get possible action/object combinations
-    def getPossibleActionObjectCombinations(self):
-        snake_case_deprecation_warning()
-
-        return self.get_possible_action_object_combinations()
-
-    # Get a list of object types and their IDs
-    def getObjectTypes(self):
-        snake_case_deprecation_warning()
-
-        return self.get_object_types()
-
-    # Get the vocabulary of the model (at the current state)
-    def getVocabulary(self):
-        snake_case_deprecation_warning()
-
-        return self.get_vocabulary()
-
-
-    def getNumMoves(self):
-        snake_case_deprecation_warning()
-
-        return self.get_num_moves()
-
-    def getTaskDescription(self):
-        snake_case_deprecation_warning()
-
-        return self.get_task_description()
-
-    #
-    # History
-    #
-    def getRunHistory(self):
-        snake_case_deprecation_warning()
-
-        return self.get_run_history()
-
-
-    # History saving (provides an API to do this, so it's consistent across agents)
-    def storeRunHistory(self, episodeIdxKey, notes):
-        snake_case_deprecation_warning()
-
-        self.store_run_history(episodeIdxKey, notes)
-
-    def saveRunHistories(self, filenameOutPrefix):
-        snake_case_deprecation_warning()
-
-        self.save_run_histories(filenameOutPrefix)
-
-    def getRunHistorySize(self):
-        snake_case_deprecation_warning()
-
-        return self.get_run_historySize()
-
-    def clearRunHistories(self):
-        snake_case_deprecation_warning()
-
-        self.clear_run_histories()
-
-    # A one-stop function to handle saving.
-    def saveRunHistoriesBufferIfFull(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
-        snake_case_deprecation_warning()
-
-        self.save_run_histories_buffer_if_full(filenameOutPrefix, maxPerFile, forceSave)
-
-    #
-    # Train/development/test sets
-    #
-    def getVariationsTrain(self):
-        snake_case_deprecation_warning()
-
-        return self.get_variations_train()
-
-    def getVariationsDev(self):
-        snake_case_deprecation_warning()
-
-        return self.get_variations_dev()
-
-    def getVariationsTest(self):
-        snake_case_deprecation_warning()
-
-        return self.get_variations_test()
-
-    def getRandomVariationTrain(self):
-        snake_case_deprecation_warning()
-
-        return self.get_random_variation_train()
-
-    def getRandomVariationDev(self):
-        snake_case_deprecation_warning()
-
-        return self.get_random_variation_dev()
-
-    def getRandomVariationTest(self):
-        snake_case_deprecation_warning()
-
-        return self.get_random_variation_test()
-
-    # Gold action sequence
-    def getGoldActionSequence(self):
-        snake_case_deprecation_warning()
-
-        return self.get_gold_action_sequence()
-
-    # Step
-    def step(self, inputStr:str):
-        observation = self.server.step(inputStr)
-        score = int(round(100 * self.server.getScore()))        # Convert from 0-1 to 0-100
-        isCompleted = self.server.getCompleted()
-        numMoves = self.getNumMoves()
-
-        # Calculate reward
-        reward = score - self.lastStepScore         # Calculate reward (delta score) for this step
-        self.lastStepScore = score                  # Store current score for reward calculation on the next step
-
-
-        # If the number of moves exceeds the environment step limit, then set isCompleted to be true
-        if (numMoves > self.envStepLimit):
-            isCompleted = True
-
-        # New: Handle this in the API rather than the agent -- if the score is less than zero, then set the isCompleted flag to true.
-        if (score < 0):
-            isCompleted = True
-
-        # Mirror of Jericho API
-        infos = {
-            'moves': numMoves,
-            'score': score,
-            'reward': reward,
-            'look': self.look(),
-            'inv': self.inventory(),
-            'taskDesc': self.taskdescription(),
-            'valid': self.getValidActionObjectCombinations(),
-            'variationIdx': self.variationIdx,
-            'taskName': self.taskName,
-            'simplificationStr': self.simplificationStr,
-        }
-
-        return observation, reward, isCompleted, infos
-
-
-    # Special actions that are "free" (consume zero time)
-    def look(self):
-        observation = self.server.freeActionLook()
-        return observation
-
-    def inventory(self):
-        observation = self.server.freeActionInventory()
-        return observation
-
-    def taskdescription(self):
-        observation = self.server.freeActionTaskDesc()
-        return observation
-
-    # Goal progress
-    def getGoalProgressStr(self):
-        snake_case_deprecation_warning()
-
-        return self.get_goal_progress_str()
-
-    ########################## SNAKE CASE METHODS #############################
-    # As of 23-12-15, snake case methods are the official methods. The camelCase
-    # methods are just wrapper functions.
-
-
-    # Simplifications
-    def get_simplifications_used(self):
-        return self.server.getSimplificationsUsed()
-
-    def get_possible_simplifications(self):
-        return self.server.getPossibleSimplifications().split(", ")
 
     def get_task_names(self):
         """ Get the name for the supported tasks in ScienceWorld. """
@@ -405,7 +166,7 @@ class ScienceWorldEnv:
         return data
 
     # As above, but dictionary is referenced by object type ID
-    def getPossibleObjectReferentTypesLUT(self):
+    def get_possible_object_referent_types_LUT(self):
         jsonStr = self.server.getPossibleObjectReferentTypesLUTJSON()
         data = json.loads(jsonStr)
         return data
@@ -546,10 +307,243 @@ class ScienceWorldEnv:
         else:
             return ["ERROR: Gold path was not generated.  Set `generateGoldPath` flag to true when calling load()."]
 
+
+    # Step
+    def step(self, inputStr:str):
+        observation = self.server.step(inputStr)
+        score = int(round(100 * self.server.getScore()))        # Convert from 0-1 to 0-100
+        isCompleted = self.server.getCompleted()
+        numMoves = self.getNumMoves()
+
+        # Calculate reward
+        reward = score - self.lastStepScore         # Calculate reward (delta score) for this step
+        self.lastStepScore = score                  # Store current score for reward calculation on the next step
+
+
+        # If the number of moves exceeds the environment step limit, then set isCompleted to be true
+        if (numMoves > self.envStepLimit):
+            isCompleted = True
+
+        # New: Handle this in the API rather than the agent -- if the score is less than zero, then set the isCompleted flag to true.
+        if (score < 0):
+            isCompleted = True
+
+        # Mirror of Jericho API
+        infos = {
+            'moves': numMoves,
+            'score': score,
+            'reward': reward,
+            'look': self.look(),
+            'inv': self.inventory(),
+            'taskDesc': self.taskdescription(),
+            'valid': self.getValidActionObjectCombinations(),
+            'variationIdx': self.variationIdx,
+            'taskName': self.taskName,
+            'simplificationStr': self.simplificationStr,
+        }
+
+        return observation, reward, isCompleted, infos
+
+
+    # Special actions that are "free" (consume zero time)
+    def look(self):
+        observation = self.server.freeActionLook()
+        return observation
+
+    def inventory(self):
+        observation = self.server.freeActionInventory()
+        return observation
+
+    def taskdescription(self):
+        observation = self.server.freeActionTaskDesc()
+        return observation
+
     # Goal progress
     def get_goal_progress_str(self):
         goalStr = self.server.getGoalProgressStr()
         return goalStr
+
+
+    ####################### Camel Case Methods ################################
+    # All of the wrapper methods for camel case, to avoid breaking projects.
+
+    # Simplifications
+    def getSimplificationsUsed(self):
+        snake_case_deprecation_warning()
+
+        return self.get_simplifications_used()
+
+    def getPossibleSimplifications(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_simplifications()
+
+    def getTaskNames(self):
+        """ Get the name for the supported tasks in ScienceWorld. """
+        snake_case_deprecation_warning()
+
+        return self.get_task_names()
+
+    # Get the maximum number of variations for this task
+    def getMaxVariations(self, taskName):
+        snake_case_deprecation_warning()
+
+        return self.get_max_variations(taskName)
+
+    # Get possible actions
+    def getPossibleActions(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_actions()
+
+    # Get possible actions (and also include the template IDs for those actions)
+    def getPossibleActionsWithIDs(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_actions_with_IDs()
+
+    # Get possible objects
+    def getPossibleObjects(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_objects()
+
+    # Get a list of object_ids to unique referents
+    def getPossibleObjectReferentLUT(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_object_referent_LUT()
+
+    # As above, but dictionary is referenced by object type ID
+    def getPossibleObjectReferentTypesLUT(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_object_referent_types_LUT()
+
+    # Get a list of *valid* agent-object combinations
+    def getValidActionObjectCombinations(self):
+        snake_case_deprecation_warning()
+
+        return self.get_valid_action_object_combinations()
+
+    def getValidActionObjectCombinationsWithTemplates(self):
+        snake_case_deprecation_warning()
+
+        return self.get_valid_action_object_combinations_with_templates()
+
+    # Get a LUT of object_id to type_id
+    def getAllObjectTypesLUTJSON(self):
+        snake_case_deprecation_warning()
+
+        return self.get_all_object_types_LUTJSON()
+
+    # Get a LUT of {object_id: {type_id, referent:[]} } tuples
+    def getAllObjectIdsTypesReferentsLUTJSON(self):
+        snake_case_deprecation_warning()
+
+        return self.get_all_object_ids_types_referents_LUTJSON()
+
+    # Get possible action/object combinations
+    def getPossibleActionObjectCombinations(self):
+        snake_case_deprecation_warning()
+
+        return self.get_possible_action_object_combinations()
+
+    # Get a list of object types and their IDs
+    def getObjectTypes(self):
+        snake_case_deprecation_warning()
+
+        return self.get_object_types()
+
+    # Get the vocabulary of the model (at the current state)
+    def getVocabulary(self):
+        snake_case_deprecation_warning()
+
+        return self.get_vocabulary()
+
+
+    def getNumMoves(self):
+        snake_case_deprecation_warning()
+
+        return self.get_num_moves()
+
+    def getTaskDescription(self):
+        snake_case_deprecation_warning()
+
+        return self.get_task_description()
+
+    def getRunHistory(self):
+        snake_case_deprecation_warning()
+
+        return self.get_run_history()
+
+    def storeRunHistory(self, episodeIdxKey, notes):
+        snake_case_deprecation_warning()
+
+        self.store_run_history(episodeIdxKey, notes)
+
+    def saveRunHistories(self, filenameOutPrefix):
+        snake_case_deprecation_warning()
+
+        self.save_run_histories(filenameOutPrefix)
+
+    def getRunHistorySize(self):
+        snake_case_deprecation_warning()
+
+        return self.get_run_historySize()
+
+    def clearRunHistories(self):
+        snake_case_deprecation_warning()
+
+        self.clear_run_histories()
+
+    # A one-stop function to handle saving.
+    def saveRunHistoriesBufferIfFull(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
+        snake_case_deprecation_warning()
+
+        self.save_run_histories_buffer_if_full(filenameOutPrefix, maxPerFile, forceSave)
+
+    def getVariationsTrain(self):
+        snake_case_deprecation_warning()
+
+        return self.get_variations_train()
+
+    def getVariationsDev(self):
+        snake_case_deprecation_warning()
+
+        return self.get_variations_dev()
+
+    def getVariationsTest(self):
+        snake_case_deprecation_warning()
+
+        return self.get_variations_test()
+
+    def getRandomVariationTrain(self):
+        snake_case_deprecation_warning()
+
+        return self.get_random_variation_train()
+
+    def getRandomVariationDev(self):
+        snake_case_deprecation_warning()
+
+        return self.get_random_variation_dev()
+
+    def getRandomVariationTest(self):
+        snake_case_deprecation_warning()
+
+        return self.get_random_variation_test()
+
+    def getGoldActionSequence(self):
+        snake_case_deprecation_warning()
+
+        return self.get_gold_action_sequence()
+
+    def getGoalProgressStr(self):
+        snake_case_deprecation_warning()
+
+        return self.get_goal_progress_str()
+
+
 
 
 class BufferedHistorySaver:

--- a/scienceworld/scienceworld.py
+++ b/scienceworld/scienceworld.py
@@ -122,12 +122,12 @@ class ScienceWorldEnv:
     def getSimplificationsUsed(self):
         snake_case_deprecation_warning()
 
-        return self.server.getSimplificationsUsed()
+        return self.get_simplifications_used()
 
     def getPossibleSimplifications(self):
         snake_case_deprecation_warning()
 
-        return self.server.getPossibleSimplifications().split(", ")
+        return self.get_possible_simplifications()
 
     @property
     def tasks(self):
@@ -143,125 +143,95 @@ class ScienceWorldEnv:
         """ Get the name for the supported tasks in ScienceWorld. """
         snake_case_deprecation_warning()
 
-        return list(self.server.getTaskNames())
+        return self.get_task_names()
 
     # Get the maximum number of variations for this task
     def getMaxVariations(self, taskName):
         snake_case_deprecation_warning()
 
-        return self.server.getTaskMaxVariations(infer_task(taskName))
+        return self.get_max_variations(taskName)
 
     # Get possible actions
     def getPossibleActions(self):
         snake_case_deprecation_warning()
 
-        return list(self.server.getPossibleActions())
+        return self.get_possible_actions()
 
     # Get possible actions (and also include the template IDs for those actions)
     def getPossibleActionsWithIDs(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getPossibleActionsWithIDs()
-        data = json.loads(jsonStr)
-        return data
+        return self.get_possible_actions_with_IDs()
 
     # Get possible objects
     def getPossibleObjects(self):
         snake_case_deprecation_warning()
 
-        return list(self.server.getPossibleObjects())
+        return self.get_possible_objects()
 
     # Get a list of object_ids to unique referents
     def getPossibleObjectReferentLUT(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getPossibleObjectReferentLUTJSON()
-        data = json.loads(jsonStr)
-        return data
+        return self.get_possible_object_referent_LUT()
 
     # As above, but dictionary is referenced by object type ID
     def getPossibleObjectReferentTypesLUT(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getPossibleObjectReferentTypesLUTJSON()
-        data = json.loads(jsonStr)
-        return data
+        return self.get_possible_object_referent_types_LUT()
 
     # Get a list of *valid* agent-object combinations
     def getValidActionObjectCombinations(self):
         snake_case_deprecation_warning()
 
-        return list(self.server.getValidActionObjectCombinations())
+        return self.get_valid_action_object_combinations()
 
     def getValidActionObjectCombinationsWithTemplates(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getValidActionObjectCombinationsJSON()
-        data = json.loads(jsonStr)
-        return data['validActions']
+        return self.get_valid_action_object_combinations_with_templates()
 
     # Get a LUT of object_id to type_id
     def getAllObjectTypesLUTJSON(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getAllObjectTypesLUTJSON()
-        data = json.loads(jsonStr)
-        return data
+        return self.get_all_object_types_LUTJSON()
 
     # Get a LUT of {object_id: {type_id, referent:[]} } tuples
     def getAllObjectIdsTypesReferentsLUTJSON(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getAllObjectIdsTypesReferentsLUTJSON()
-        data = json.loads(jsonStr)
-        return data
+        return self.get_all_object_ids_types_referents_LUTJSON()
 
     # Get possible action/object combinations
     def getPossibleActionObjectCombinations(self):
         snake_case_deprecation_warning()
 
-        combinedJSON = self.server.getPossibleActionObjectCombinationsJSON()
-        data = json.loads(combinedJSON)
-        templates = data['templates']
-        lookUpTable = data['lookUpTable']
-
-        return (templates, lookUpTable)
+        return self.get_possible_action_object_combinations()
 
     # Get a list of object types and their IDs
     def getObjectTypes(self):
         snake_case_deprecation_warning()
 
-        jsonStr = self.server.getObjectTypesLUTJSON()
-        data = json.loads(jsonStr)
-        return data
+        return self.get_object_types()
 
     # Get the vocabulary of the model (at the current state)
     def getVocabulary(self):
         snake_case_deprecation_warning()
 
-        vocab = set()
-
-        # Action vocabulary
-        for actionStr in self.getPossibleActions():
-            for word in actionStr.split(" "):
-                vocab.add(word)
-
-        # Object vocabulary (keep as compound nouns?)
-        vocabObjects = self.getPossibleObjects()
-        vocab = vocab.union( set(vocabObjects) )
-
-        return vocab
+        return self.get_vocabulary()
 
 
     def getNumMoves(self):
         snake_case_deprecation_warning()
 
-        return self.server.getNumMoves()
+        return self.get_num_moves()
 
     def getTaskDescription(self):
         snake_case_deprecation_warning()
 
-        return self.server.getTaskDescription()
+        return self.get_task_description()
 
     #
     # History
@@ -269,61 +239,35 @@ class ScienceWorldEnv:
     def getRunHistory(self):
         snake_case_deprecation_warning()
 
-        historyStr = self.server.getRunHistoryJSON()
-        jsonOut = json.loads(historyStr)
-        return jsonOut
+        return self.get_run_history()
 
 
     # History saving (provides an API to do this, so it's consistent across agents)
     def storeRunHistory(self, episodeIdxKey, notes):
         snake_case_deprecation_warning()
 
-        packed = {
-            'episodeIdx': episodeIdxKey,
-            'notes': notes,
-            'history': self.getRunHistory()
-        }
-
-        self.runHistories[episodeIdxKey] = packed
+        self.store_run_history(episodeIdxKey, notes)
 
     def saveRunHistories(self, filenameOutPrefix):
         snake_case_deprecation_warning()
 
-        # Save history
-
-        # Create verbose filename
-        filenameOut = filenameOutPrefix
-        keys = sorted(self.runHistories.keys())
-        if (len(keys) > 0):
-            keyFirst = keys[0]
-            keyLast = keys[-1]
-            filenameOut += "-" + str(keyFirst) + "-" + str(keyLast)
-
-        filenameOut += ".json"
-
-        logger.info("* Saving run history (" + str(filenameOut) + ")...")
-
-        with open(filenameOut, 'w') as outfile:
-            json.dump(self.runHistories, outfile, sort_keys=True, indent=4)
+        self.save_run_histories(filenameOutPrefix)
 
     def getRunHistorySize(self):
         snake_case_deprecation_warning()
 
-        return len(self.runHistories)
+        return self.get_run_historySize()
 
     def clearRunHistories(self):
         snake_case_deprecation_warning()
 
-        self.runHistories = {}
+        self.clear_run_histories()
 
     # A one-stop function to handle saving.
     def saveRunHistoriesBufferIfFull(self, filenameOutPrefix, maxPerFile=1000, forceSave=False):
         snake_case_deprecation_warning()
 
-        if ((self.getRunHistorySize() >= maxPerFile) or (forceSave == True)):
-            self.saveRunHistories(filenameOutPrefix)
-            self.clearRunHistories()
-
+        self.save_run_histories_buffer_if_full(filenameOutPrefix, maxPerFile, forceSave)
 
     #
     # Train/development/test sets
@@ -331,41 +275,38 @@ class ScienceWorldEnv:
     def getVariationsTrain(self):
         snake_case_deprecation_warning()
 
-        return list(self.server.getVariationsTrain())
+        return self.get_variations_train()
 
     def getVariationsDev(self):
         snake_case_deprecation_warning()
 
-        return list(self.server.getVariationsDev())
+        return self.get_variations_dev()
 
     def getVariationsTest(self):
         snake_case_deprecation_warning()
 
-        return list(self.server.getVariationsTest())
+        return self.get_variations_test()
 
     def getRandomVariationTrain(self):
         snake_case_deprecation_warning()
 
-        return self.server.getRandomVariationTrain()
+        return self.get_random_variation_train()
 
     def getRandomVariationDev(self):
         snake_case_deprecation_warning()
 
-        return self.server.getRandomVariationDev()
+        return self.get_random_variation_dev()
 
     def getRandomVariationTest(self):
         snake_case_deprecation_warning()
 
-        return self.server.getRandomVariationTest()
+        return self.get_random_variation_test()
 
     # Gold action sequence
     def getGoldActionSequence(self):
         snake_case_deprecation_warning()
 
-        if (self.goldPathGenerated == True):
-            return list(self.server.getGoldActionSequence())
-        else:
-            return ["ERROR: Gold path was not generated.  Set `generateGoldPath` flag to true when calling load()."]
+        return self.get_gold_action_sequence()
 
     # Step
     def step(self, inputStr:str):
@@ -421,13 +362,11 @@ class ScienceWorldEnv:
     def getGoalProgressStr(self):
         snake_case_deprecation_warning()
 
-        goalStr = self.server.getGoalProgressStr()
-        return goalStr
+        return self.get_goal_progress_str()
 
     ########################## SNAKE CASE METHODS #############################
-    # As of 23-12-14, all of the snake case methods are exact copies of their 
-    # camelCase counterparts (except that they use snake case in the method name
-    # and that they use the snake case variants of methods)
+    # As of 23-12-15, snake case methods are the official methods. The camelCase
+    # methods are just wrapper functions.
 
 
     # Simplifications

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -23,4 +23,4 @@ def infer_task(name_or_id):
 def snake_case_deprecation_warning():
     message = "You are using the camel case api. This feature is deprecated. Please migrate to the snake_case api."
     formatted_message = f"\033[91m {message} \033[00m"
-    warnings.warn(formatted_message, UserError, stacklevel=2)
+    warnings.warn(formatted_message, UserWarning, stacklevel=2)

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -1,6 +1,5 @@
 import re
-import logging
-import traceback
+import warnings
 
 from scienceworld.constants import NAME2ID, ID2TASK
 
@@ -21,24 +20,7 @@ def infer_task(name_or_id):
     return name_or_id
 
 
-def deprecated_api_warning(logger, pending=True, camel_case=True):
-
-    if pending:
-        depstatus = "This feature will be deprecated soon."
-    else:
-        depstatus = "This feature is deprecated."
-
-    if camel_case:
-        message = f"You are using the camel case naming convention for the"\
-                    f"python API. {depstatus} Please use snake case instead."
-    else:
-        message = f"{depstatus}. Please migrate away from this feature, as it may lead to"\
-                    "unexpected behavior."
-
-    formatted_message = f"\033[91m {message}\033[00m\nStack Trace:\n"
-    
-    s = traceback.format_stack()
-    for stack_el in s[:-2]:
-        formatted_message += stack_el
-
-    logger.warning(formatted_message)
+def snake_case_deprecation_warning():
+    message = "You are using the camel case api. This feature is deprecated. Please migrate to the snake_case api."
+    formatted_message = f"\033[91m {message} \033[00m"
+    warnings.warn(formatted_message, UserError, stacklevel=2)

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -26,7 +26,7 @@ def deprecated_api_warning(pending=True, camel_case=True):
     else:
         depstatus = "This feature is deprecated."
 
-    if snake_case:
+    if camel_case:
         message = f"You are using the camel case naming convention for the \
                 python API. {depstatus} Please use snake case instead."
     else:

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 from scienceworld.constants import NAME2ID, ID2TASK
 
@@ -17,3 +18,25 @@ def infer_task(name_or_id):
     name_or_id = re.sub(r"task-(\d|a|b)+-|[()]", "", name_or_id)
 
     return name_or_id
+
+
+def deprecated_api_warning(pending=True, camel_case=True):
+    if pending:
+        depstatus = "This feature will be deprecated soon."
+    else:
+        depstatus = "This feature is deprecated."
+
+    if snake_case:
+        message = f"You are using the camel case naming convention for the \
+                python API. {depstatus} Please use snake case instead."
+    else:
+        message = f"{depstatus}. Please do not use it, as it may lead to \
+                unexpected behavior."
+
+    if pending:
+        category = PendingDeprecationWarning
+    else:
+        category = DeprecationWarning
+
+
+    warnings.warn(message, category, stacklevel=2)

--- a/scienceworld/utils.py
+++ b/scienceworld/utils.py
@@ -1,5 +1,6 @@
 import re
-import warnings
+import logging
+import traceback
 
 from scienceworld.constants import NAME2ID, ID2TASK
 
@@ -20,23 +21,24 @@ def infer_task(name_or_id):
     return name_or_id
 
 
-def deprecated_api_warning(pending=True, camel_case=True):
+def deprecated_api_warning(logger, pending=True, camel_case=True):
+
     if pending:
         depstatus = "This feature will be deprecated soon."
     else:
         depstatus = "This feature is deprecated."
 
     if camel_case:
-        message = f"You are using the camel case naming convention for the \
-                python API. {depstatus} Please use snake case instead."
+        message = f"You are using the camel case naming convention for the"\
+                    f"python API. {depstatus} Please use snake case instead."
     else:
-        message = f"{depstatus}. Please do not use it, as it may lead to \
-                unexpected behavior."
+        message = f"{depstatus}. Please migrate away from this feature, as it may lead to"\
+                    "unexpected behavior."
 
-    if pending:
-        category = PendingDeprecationWarning
-    else:
-        category = DeprecationWarning
+    formatted_message = f"\033[91m {message}\033[00m\nStack Trace:\n"
+    
+    s = traceback.format_stack()
+    for stack_el in s[:-2]:
+        formatted_message += stack_el
 
-
-    warnings.warn(message, category, stacklevel=2)
+    logger.warning(formatted_message)


### PR DESCRIPTION
The camel case python API does not follow PEP 8, and I found it a little tricky to tell between scala and python methods. To fix this, I added new, duplicate methods, that follow (in my opinion) pythonic naming convention. Some of the duplicate methods can be seen below:

![Screenshot from 2023-12-14 17-03-38](https://github.com/allenai/ScienceWorld/assets/94922098/aa46e848-3048-4129-bc04-473eec556e5a)

I also added a deprecated_api_warning method to utils.py.
![Screenshot from 2023-12-14 17-04-07](https://github.com/allenai/ScienceWorld/assets/94922098/00554f96-091d-417f-b1fd-9d73709abc60)

I then stuck it in to every camel case method.
![Screenshot from 2023-12-14 17-03-05](https://github.com/allenai/ScienceWorld/assets/94922098/e24558e0-0da6-4d46-a15b-72f5366bbad1)

Potential follow ups:
- Remove any actual functionality from the camel case API and have them just be wrapper functions for the snake case methods that throw up a warning when used. 
- Implement more elegant warning logging
- Something else?

Any feedback would be greatly appreciated!