### PR TITLE
Make simulator state transitions deterministic

### DIFF
--- a/simulator/build.sbt
+++ b/simulator/build.sbt
@@ -2,7 +2,7 @@ name := "scienceworld-scala"
 
 version := "1.2.3"
 
-scalaVersion := "2.12.9"
+scalaVersion := "2.12.21"
 
 resolvers += "jetbrains-intellij-dependencies" at "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies"
 

--- a/simulator/project/build.properties
+++ b/simulator/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.11

--- a/simulator/src/main/scala/scienceworld/struct/EnvObject.scala
+++ b/simulator/src/main/scala/scienceworld/struct/EnvObject.scala
@@ -613,6 +613,8 @@ class EnvObject(var name:String, var objType:String, includeElectricalTerminals:
     }
   }
 
+  override def hashCode():Int = java.lang.Long.hashCode(this.uuid)
+
 
   /*
    * String methods

--- a/tests/test_scienceworld.py
+++ b/tests/test_scienceworld.py
@@ -13,6 +13,32 @@ def test_observation_is_deterministic():
         assert obs == obs_orig
 
 
+def test_action_trace_is_deterministic():
+    """Reset must reproduce stateful physics, not only the initial description."""
+    env = ScienceWorldEnv()
+    env.load("task-1-boil", 0, "teleportAction")
+    actions = [
+        "teleport to kitchen",
+        "pour counter into sink",
+        "activate sink",
+        "use lighter on drawer",
+        "look around",
+    ]
+
+    traces = []
+    try:
+        for _ in range(8):
+            observation, info = env.reset()
+            trace = [(observation, info)]
+            for action in actions:
+                trace.append(env.step(action))
+            traces.append(trace)
+    finally:
+        env.close()
+
+    assert all(trace == traces[0] for trace in traces[1:])
+
+
 def test_multiple_instances():
     env1 = ScienceWorldEnv("1-1")
     env2 = ScienceWorldEnv("1-1")


### PR DESCRIPTION
I made simulator state transitions deterministic, which resolved #82 and #33 . Instead of replacing `Set` with `Array`, it can be done more elegantly. Any test is welcome.