### PR TITLE
Fix reversed anode/cathode polarity on battery/generator

### DIFF
--- a/simulator/src/main/scala/scienceworld/objects/electricalcomponent/Generator.scala
+++ b/simulator/src/main/scala/scienceworld/objects/electricalcomponent/Generator.scala
@@ -21,8 +21,8 @@ class Generator(val displayOnOff:Boolean = true) extends PolarizedElectricalComp
   override def tick(): Boolean = {
     // If this generator is activated, then generate a voltage potential at the terminals.
     if (this.propDevice.get.isActivated) {
-      this.anode.voltage = Some(VOLTAGE_GENERATOR)
-      this.cathode.voltage = Some(VOLTAGE_GROUND)
+      this.anode.voltage = Some(VOLTAGE_GROUND)
+      this.cathode.voltage = Some(VOLTAGE_GENERATOR)
     } else {
       this.anode.voltage = None
       this.cathode.voltage = None

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricCircuit.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricCircuit.scala
@@ -304,8 +304,8 @@ class TaskElectricCircuit(val mode:String = MODE_POWER_COMPONENT) extends TaskPa
         // This should never happen?
       }
     }
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
 
 
     // Wait one moment, for the power to cycle
@@ -421,8 +421,8 @@ class TaskElectricCircuit(val mode:String = MODE_POWER_COMPONENT) extends TaskPa
         // This should never happen?
       }
     }
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
 
     // If power source is non-renewable, we need to turn it on
     if (powerSourceDescription == "nonrenewable") {

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity.scala
@@ -516,8 +516,8 @@ class TaskElectricalConductivity(val mode:String = MODE_TEST_CONDUCTIVITY) exten
         // This should never happen?
       }
     }
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire3, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire3, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
 
     // Connect substance to test
     if ((substance.get.propMaterial.isEmpty) || (substance.get.propMaterial.get.stateOfMatter == "solid")) {
@@ -673,8 +673,8 @@ class TaskElectricalConductivity(val mode:String = MODE_TEST_CONDUCTIVITY) exten
         // This should never happen?
       }
     }
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
 
     // If power source is non-renewable, we need to turn it on
     if (powerSourceDescription == "nonrenewable") {

--- a/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity2.scala
+++ b/simulator/src/main/scala/scienceworld/tasks/specifictasks/TaskElectricalConductivity2.scala
@@ -375,8 +375,8 @@ class TaskElectricalConductivity2(val mode:String = MODE_TEST_CONDUCTIVITY_UNKNO
         // This should never happen?
       }
     }
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
-    runAction("connect " + PathFinder.getObjUniqueReferent(wire3, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire1, getCurrentAgentLocation(runner)).get + " terminal 2 to " + anodeReferent, runner)   // to device anode
+    runAction("connect " + PathFinder.getObjUniqueReferent(wire3, getCurrentAgentLocation(runner)).get + " terminal 2 to " + cathodeReferent, runner)   // to device cathode
 
     // Connect substance to test
     runAction("connect " + substance.get.name + " terminal 1 to " + PathFinder.getObjUniqueReferent(wire2, getCurrentAgentLocation(runner)).get + " terminal 2", runner)


### PR DESCRIPTION
## Summary

Fixes #50.

`Generator.tick()` assigned voltage to the anode and ground to the cathode, but `PolarizedElectricalComponent.tick()` (inherited by `LightBulb`, `ElectricMotor`, `ElectricBuzzer`) only activates a load when its anode connects to ground and its cathode connects to voltage. Because `Terminal.connectsToGround()` stops traversal as soon as it reaches a generator terminal, this mismatch meant wiring a battery "naturally" (anode-to-anode, cathode-to-cathode, as the issue describes) never completed a circuit — only the crossed wiring (anode-to-cathode) worked. This is exactly why the gold-agent action sequences had been wiring devices crossed as a workaround.

- Swap the terminal voltage assignment in `Generator.tick()` (`simulator/.../Generator.scala`) so activation now requires natural, same-name wiring. This fixes `Battery` and every other source that extends `Generator` (`GasGenerator`, `NuclearGenerator`, `SolarPanel`, `WindGenerator`) without touching the load side.
- Update the gold action sequences in `TaskElectricCircuit`, `TaskElectricalConductivity`, and `TaskElectricalConductivity2` to wire devices naturally instead of crossed, matching the fixed polarity.
- Rebuild `scienceworld/scienceworld.jar`.

The issue also asks to "regenerate training data" — that refers to the separately-built `goldpaths-all.zip` archive produced by an external/offline process outside this repo, out of scope for this change.

## Test plan

- [x] `./simulator/package.sh` — builds cleanly; rebuilt jar is byte-identical to the committed one
- [x] Replayed the gold action sequence for all 4 affected tasks via the Python API — each now wires anode-to-anode/cathode-to-cathode and reaches score 100: `task-2-power-component`, `task-2-power-component-(renewable-vs-nonrenewable-energy)`, `task-2a-test-conductivity`, `task-2a-test-conductivity-of-unknown-substances`
- [x] `pytest tests/test_scienceworld.py` — 7 passed
- [x] `tox -e flake8` — clean
- [x] `tox -e precommit` — clean on all hooks that apply to the changed files (the `shellcheck` hook itself can't run in this sandbox due to a CPU-architecture mismatch in the downloaded binary, unrelated to this change — no shell scripts were touched)
- [ ] Full OS × Python CI matrix — relies on GitHub Actions, which will run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)